### PR TITLE
530 use softplus transformation of lcc

### DIFF
--- a/CIMS/lcc_calculation.py
+++ b/CIMS/lcc_calculation.py
@@ -63,7 +63,6 @@ def lcc_calculation(sub_graph, node, year, model, **kwargs):
 
     # Check if the node is a tech compete node:
     if model.get_param(PARAM.competition_type, node) in ['tech compete']:
-        total_lcc_v = 0.0
         v = model.get_param(PARAM.heterogeneity, node, year)
 
         # Get all the technologies in the node
@@ -101,27 +100,6 @@ def lcc_calculation(sub_graph, node, year, model, **kwargs):
                                                                 do_calc=True)
             val_dict = {PARAM.year_value: lcc_competition, PARAM.param_source: lcc_competition_source}
             model.set_param_internal(val_dict, PARAM.lcc_competition, node, year, tech)
-
-            # If the technology is available in this year, add to the total LCC^-v value.
-            first_year_avail = model.get_param(PARAM.available, node, str(model.base_year), tech=tech)
-            first_year_unavail = model.get_param(PARAM.unavailable, node, str(model.base_year),
-                                                 tech=tech)
-            if first_year_avail <= int(year) < first_year_unavail:
-                # Life Cycle Cost ^ -v
-                if lcc < 0.01:
-                    # When lcc < 0.01, we will approximate its weight using a TREND line
-                    w1 = 0.1 ** (-1 * v)
-                    w2 = 0.01 ** (-1 * v)
-                    slope = (w2 - w1) / (0.01 - 0.1)
-                    weight = slope * lcc + (w1 - slope * 0.1)
-                else:
-                    weight = lcc ** (-1 * v)
-
-                total_lcc_v += weight
-
-        # Set sum of Life Cycle Cost raised to negative variance
-        val_dict = construction.create_value_dict(total_lcc_v, param_source='calculation')
-        sub_graph.nodes[node][year][PARAM.total_lcc_v] = val_dict
 
         # Weighted Life Cycle Cost
         # ************************
@@ -287,6 +265,37 @@ def calc_lcc_competition(model: "CIMS.Model", node: str, year: str, tech: str) -
                    fixed_cost_rate + emissions_cost
 
     return lcc_competition
+
+
+def calc_lcc_retrofit(model, node, year, existing_tech):
+    """
+    Calculates the LCC to be used by the current technology during a retrofit competition.
+    This differs from regular LCC by excluding all upfront costs.
+
+    Parameters
+    ----------
+    model : CIMS.Model
+        The model where LCC components are stored. Must contain node.
+    node : str
+        The name of the node (branch notation) where the LCC components can be found.
+    year : str
+        The year of interest.
+    existing_tech : str
+        The existing technology whose LCC is being calculated.
+
+    Returns
+    -------
+    float :
+        The LCC to use for the current technology during a retrofit competition.
+    """
+    competition_annual_cost = model.get_param(PARAM.competition_annual_cost, node, year,
+                                           tech=existing_tech, do_calc=True)
+    annual_service_cost = model.get_param(PARAM.service_cost, node, year,
+                                          tech=existing_tech, do_calc=True)
+    emissions_cost = model.get_param(PARAM.emissions_cost, node, year,
+                                     tech=existing_tech, do_calc=True)
+    retrofit_lcc_competition = competition_annual_cost + annual_service_cost + emissions_cost
+    return retrofit_lcc_competition
 
 
 def calc_competition_upfront_cost(model: 'CIMS.Model', node: str, year: str, tech: str) -> float:

--- a/CIMS/stock_allocation/allocation_utils.py
+++ b/CIMS/stock_allocation/allocation_utils.py
@@ -107,7 +107,7 @@ def _stable_transform(tech_lcc):
     """
     A helper function of _find_competing_weights(). To handle negative and zero value lcc's, use a piecewise function:
             - when positive or zero, use the softplus transform to reduce the effect of small positive input values. This function is monotonic (strictly increasing) and introduces minimal distortion for lifecycle costs greater than 3.
-            - when negative, use a monotonic, smooth equation based on softplus(-x), but approaching zero weight polynomially (rather than exponentially) to preserve behaviour of relative lifecycle costs similar to the positive number space.
+            - when negative, use a monotonic, smooth equation of (b+softplus(-x))^p. This function approaches zero weight polynomially (rather than exponentially) to preserve behaviour of relative lifecycle costs similar to the positive number space.
 
     Parameters
     ----------
@@ -119,12 +119,13 @@ def _stable_transform(tech_lcc):
     float :
         softplus transform of lcc_competition
     """
-    # The softplus transform function 'softplus(x)' is approximately equal 'x' for large values, but returns infinity for very large values of 'x'. To avoid an overflow error with the np.exp function, use a limit on the input value above where softplus(x) = x.
+    # The function 'softplus(x)' is approximately equal to 'x' for large values, but returns infinity for very large values of 'x'. To avoid an overflow error with the np.exp function, use a limit on the input value above where softplus(x) = x.
     if tech_lcc > 20:
         tech_lcc_transform = tech_lcc
     elif tech_lcc < 0:
-        # Use an exponent value of 0.7 for smooth weighting approximately equal to behaviour in positive number space
-        tech_lcc_transform = (1 + np.log1p( np.exp( -1 * np.clip( tech_lcc, -500, 0)))) ** (-0.7)
+        # Use an exponent value of p=-1 for smooth weighting, approximately equal to behaviour in positive number space.
+        # Use shift value of b=0.7495 so that softplus(x) = (0.7495 + softplus(-x))^-1 at 0.
+        tech_lcc_transform = (0.7495 + np.log1p( np.exp( -1 * np.clip( tech_lcc, -500, 0)))) ** (-1)
     else:
         # # np.log1p(y) = log(1 + y) but more accurate for small y
         # clip prevents underflow error for very negative x

--- a/CIMS/stock_allocation/allocation_utils.py
+++ b/CIMS/stock_allocation/allocation_utils.py
@@ -1,4 +1,6 @@
 from ..utils.parameter import list as PARAM
+from ..lcc_calculation import calc_lcc_retrofit
+import numpy as np
 
 def _find_competing_techs(model, node, comp_type):
     """
@@ -34,10 +36,9 @@ def _find_competing_techs(model, node, comp_type):
     return competing_technologies
 
 
-def _find_competing_weights(model, year, competing_techs, heterogeneity):
+def _find_competing_weights(model, year, heterogeneity, competing_techs, existing_tech=None):
     """
-    A helper function called by _calculate_new_market_shares() to find the total weight and
-    technology-specific weights used during market share competition.
+    A helper function called by _calculate_new_market_shares() and calc_retrofits() to find the total weight and technology-specific weights used during market share competition.
 
     Parameters
     ----------
@@ -45,12 +46,16 @@ def _find_competing_weights(model, year, competing_techs, heterogeneity):
         The model to use for retrieving values relevant to weight calculation.
     year : str
         The year of interest.
+    heterogeneity : float
+        The heterogeneity value used during market share competition.
     competing_techs : list
         A list returned from _find_competing_techs() that includes all of the technologies competing
         for market share at the given node.
-    heterogeneity : float
-        The heterogeneity value used during market share competition.
-
+    existing_tech : str, default=None
+        The name of the existing technology for which the alternative retrofit lifecycle cost will 
+        be calculated and used. If None, the function assumes a new market share competition where 
+        the full lifecycle cost is used for all technologies.
+    
     Returns
     -------
     float :
@@ -59,47 +64,70 @@ def _find_competing_weights(model, year, competing_techs, heterogeneity):
         A dictionary mapping each technology (represented by a `(node_branch, tech)`) to the weight
         it will have during market share competition.
     """
+    log_weight_all = []
+    log_weight = {}
+
+    for node_branch, tech in competing_techs:
+        tech_lcc = None
+        # retrofit existing stock
+        if tech == existing_tech:
+            tech_lcc = calc_lcc_retrofit(model, node_branch, year, tech)
+        # regular tech compete
+        else:
+            # find competing techs
+            year_avail = model.get_param(PARAM.available, node_branch, str(model.base_year), tech=tech)
+            year_unavail = model.get_param(PARAM.unavailable, node_branch, str(model.base_year), tech=tech)
+            if year_avail <= int(year) < year_unavail:
+                tech_lcc = model.get_param(PARAM.lcc_competition, node_branch, year, tech=tech)
+        
+        if tech_lcc is not None:
+            # find softplus transform for all lcc_competition values
+            tech_lcc_transform = _stable_transform(tech_lcc)
+            # use log weights to avoid overflow errors - log-sum-exp trick
+            log_weight[tech] =  (-1 * heterogeneity) * np.log(tech_lcc_transform)
+            log_weight_all.append(log_weight[tech])
+
     total_weight = 0
     weights = {}
 
     for node_branch, tech in competing_techs:
         year_avail = model.get_param(PARAM.available, node_branch, str(model.base_year), tech=tech)
         year_unavail = model.get_param(PARAM.unavailable, node_branch, str(model.base_year), tech=tech)
-        if year_avail <= int(year) < year_unavail:
-            tech_lcc = model.get_param(PARAM.lcc_competition, node_branch, year, tech=tech)
-            weight = _calculate_lcc_weight(tech_lcc, heterogeneity)
+        if (tech == existing_tech) or (year_avail <= int(year) < year_unavail):
+            # use log weights to avoid overflow errors - log-sum-exp trick
+            weight_max = max(log_weight_all)
+            weight = np.exp(log_weight[tech] - weight_max)
             weights[(node_branch, tech)] = weight
             total_weight += weight
 
     return total_weight, weights
 
 
-def _calculate_lcc_weight(tech_lcc, heterogeneity):
+def _stable_transform(tech_lcc):
     """
-    A helper function of _find_competing_weights() that calculates the weight a technology will be
-    assigned during market share competition.
-
-    If the technology's lcc is less than 0.01, we will approximate weight using a calculation
-    equivalent to Excel's TREND() function.
+    A helper function of _find_competing_weights(). To handle negative and zero value lcc's, use a piecewise function:
+            - when positive or zero, use the softplus transform to reduce the effect of small positive input values. This function is monotonic (strictly increasing) and introduces minimal distortion for lifecycle costs greater than 3.
+            - when negative, use a monotonic, smooth equation based on softplus(-x), but approaching zero weight polynomially (rather than exponentially) to preserve behaviour of relative lifecycle costs similar to the positive number space.
 
     Parameters
     ----------
     tech_lcc : float
-        The life cycle cost associated with a specific technology.
-
-    heterogeneity : float
-        The heterogeneity value the technology's node will use during market share competition.
+        The lifecycle cost associated with a specific technology.
 
     Returns
     -------
     float :
-        The weight a technology will have during market share competition.
+        softplus transform of lcc_competition
     """
-    if tech_lcc < 0.01:
-        weight_1 = 0.1 ** (-1 * heterogeneity)
-        weight_2 = 0.01 ** (-1 * heterogeneity)
-        slope = (weight_2 - weight_1) / (0.01 - 0.1)
-        weight = slope * tech_lcc + (weight_1 - slope * 0.1)
+    # The softplus transform function 'softplus(x)' is approximately equal 'x' for large values, but returns infinity for very large values of 'x'. To avoid an overflow error with the np.exp function, use a limit on the input value above where softplus(x) = x.
+    if tech_lcc > 20:
+        tech_lcc_transform = tech_lcc
+    elif tech_lcc < 0:
+        # Use an exponent value of 0.7 for smooth weighting approximately equal to behaviour in positive number space
+        tech_lcc_transform = (1 + np.log1p( np.exp( -1 * np.clip( tech_lcc, -500, 0)))) ** (-0.7)
     else:
-        weight = tech_lcc ** (-1 * heterogeneity)
-    return weight
+        # # np.log1p(y) = log(1 + y) but more accurate for small y
+        # clip prevents underflow error for very negative x
+        tech_lcc_transform = np.log1p( np.exp( np.clip( tech_lcc, -500, 20 )))
+
+    return tech_lcc_transform

--- a/CIMS/stock_allocation/retrofits.py
+++ b/CIMS/stock_allocation/retrofits.py
@@ -1,41 +1,10 @@
 """
 Retrofit module. Contains functions for retrofitting previously adopted stock.
 """
-from .allocation_utils import _find_competing_techs, _find_competing_weights, _calculate_lcc_weight
+from .allocation_utils import _find_competing_techs, _find_competing_weights
 from .market_share_limits import _min_max_ms_compliant, _get_percent_differences, \
     _make_ms_min_max_compliant, _adjust_new_market_shares
 from ..utils.parameter import list as PARAM
-
-def _retrofit_lcc(model, node, year, existing_tech):
-    """
-    Calculates the LCC to be used by the current technology during a retrofit competition.
-    This differs from regular LCC by excluding all upfront costs.
-
-    Parameters
-    ----------
-    model : CIMS.Model
-        The model where LCC components are stored. Must contain node.
-    node : str
-        The name of the node (branch notation) where the LCC components can be found.
-    year : str
-        The year of interest.
-    existing_tech : str
-        The existing technology whose LCC is being calculated.
-
-    Returns
-    -------
-    float :
-        The LCC to use for the current technology during a retrofit competition.
-    """
-    competition_annual_cost = model.get_param(PARAM.competition_annual_cost, node, year,
-                                           tech=existing_tech, do_calc=True)
-    annual_service_cost = model.get_param(PARAM.service_cost, node, year,
-                                          tech=existing_tech, do_calc=True)
-    emissions_cost = model.get_param(PARAM.emissions_cost, node, year,
-                                     tech=existing_tech, do_calc=True)
-    retrofit_lcc_competition = competition_annual_cost + annual_service_cost + emissions_cost
-    return retrofit_lcc_competition
-
 
 def _apply_retrofit_limits(model, year, existing_tech, retrofit_market_shares):
     """
@@ -252,20 +221,10 @@ def calc_retrofits(model, node, year, existing_stock):
 
     # Otherwise, we continue to do retrofits across all technologies
     for existing_node_tech in existing_stock.keys():
-
         existing_node, existing_tech = existing_node_tech
-        # Find Other Competing
-        other_competing_techs = _find_competing_techs(model, node, comp_type)
-        other_competing_techs.remove(existing_node_tech)
-        total_weight, competing_weights = _find_competing_weights(model, year,
-                                                                  other_competing_techs,
-                                                                  heterogeneity)
-
-        # Add Existing Tech's Weight
-        existing_tech_lcc = _retrofit_lcc(model, existing_node, year, existing_tech)
-        existing_tech_weight = _calculate_lcc_weight(existing_tech_lcc, heterogeneity)
-        total_weight += existing_tech_weight
-        competing_weights[existing_node_tech] = existing_tech_weight
+        # Find competing techs (including existing tech)
+        competing_techs = _find_competing_techs(model, node, comp_type)
+        total_weight, competing_weights = _find_competing_weights(model, year, heterogeneity, competing_techs, existing_tech)
 
         # Find Market shares based off of weights
         retrofit_market_shares = {}
@@ -274,12 +233,10 @@ def calc_retrofits(model, node, year, existing_stock):
                 retrofit_market_shares[tech] = competing_weights[tech] / total_weight
 
         # Adjust based on limits of existing technology
-        retrofit_market_shares = _apply_retrofit_limits(model, year, existing_node_tech,
-                                                        retrofit_market_shares)
+        retrofit_market_shares = _apply_retrofit_limits(model, year, existing_node_tech,retrofit_market_shares)
 
         # Adjust market shares based on limits of techs being retrofitted to
-        retrofit_market_shares = _adjust_retrofit_marketshares(model, year, existing_node_tech,
-                                                               retrofit_market_shares)
+        retrofit_market_shares = _adjust_retrofit_marketshares(model, year, existing_node_tech,retrofit_market_shares)
 
         pre_retro_existing_stock = existing_stock[existing_node_tech]
 
@@ -293,8 +250,7 @@ def calc_retrofits(model, node, year, existing_stock):
                     retrofit_stocks[tech] = 0
                 retrofit_stocks[tech] += post_retro_existing_stock - pre_retro_existing_stock
 
-                _record_retrofitted_stock(model, existing_node, year, existing_tech,
-                                          pre_retro_existing_stock - post_retro_existing_stock)
+                _record_retrofitted_stock(model, existing_node, year, existing_tech,pre_retro_existing_stock - post_retro_existing_stock)
 
             else:
                 if tech not in added_retrofit_stocks:

--- a/CIMS/stock_allocation/stock_allocation.py
+++ b/CIMS/stock_allocation/stock_allocation.py
@@ -648,8 +648,7 @@ def _calculate_new_market_shares(model, node, year, comp_type):
     competing_techs = _find_competing_techs(model, node, comp_type)
 
     # Find the weights that we will be using to calculate market share
-    total_weight, tech_weights = _find_competing_weights(model, year, competing_techs,
-                                                         heterogeneity)
+    total_weight, tech_weights = _find_competing_weights(model, year, heterogeneity, competing_techs)
 
     # Find the new market shares for each tech
     new_market_shares = _find_exogenous_market_shares(model, node, year)


### PR DESCRIPTION
use softplus transformation of lcc to have less distortion of market share weights near zero, change estimation method for negative and zero lcc values from linear approximation to polynomial adjusted version of softplus for behaviour similar in negative and postive lcc's, use log-sum-exp trick to avoid overflow errors, simplify retrofit code, remove unnecessary calculation of lcc weights in lcc_calculation.py
