### PR TITLE
545 force validation guard

### DIFF
--- a/CIMS/model.py
+++ b/CIMS/model.py
@@ -23,7 +23,7 @@ from . import visualize
 
 from .readers.scenario_reader import ScenarioReader
 from .readers.model_reader import ModelReader
-from .model_validation import ModelValidator
+from .model_validation import ModelValidator, ValidationError
 from .quantities import ProvidedQuantity
 from .emissions import EmissionsCost
 
@@ -223,6 +223,11 @@ class Model:
         Build the model graph from the base and scenario descriptions and
         initialize model metadata/parameters.
         """
+        if (not self.validator.file_validation_ran) or self.validator.file_validation_errors:
+            raise ValidationError(
+                "validate_files() must be run successfully (no errors) before construct_graph()"
+            )
+
         start = time.time()
         print("\n=== Constructing model graph ===")
         
@@ -421,6 +426,11 @@ class Model:
 
         """
         start = time.time()
+
+        if (not self.validator.graph_validation_ran) or self.validator.graph_validation_errors:
+            raise ValidationError(
+                "validate_graph() must be run successfully (no errors) before run()"
+            )
 
         if self.status != "graph constructed" or self.graph.number_of_nodes() == 0:
             raise ValueError(

--- a/CIMS/model.py
+++ b/CIMS/model.py
@@ -225,7 +225,8 @@ class Model:
         """
         if (not self.validator.file_validation_ran) or self.validator.file_validation_errors:
             raise ValidationError(
-                "validate_files() must be run successfully (no errors) before construct_graph()"
+                "CIMS.Model.validate_files() must be run successfully (no errors) before "
+                "CIMS.Model.construct_graph()"
             )
 
         start = time.time()
@@ -429,7 +430,8 @@ class Model:
 
         if (not self.validator.graph_validation_ran) or self.validator.graph_validation_errors:
             raise ValidationError(
-                "validate_graph() must be run successfully (no errors) before run()"
+                "CIMS.Model.validate_graph() must be run successfully (no errors) before "
+                "CIMS.Model.run()"
             )
 
         if self.status != "graph constructed" or self.graph.number_of_nodes() == 0:

--- a/CIMS/model_validation/ModelValidator.py
+++ b/CIMS/model_validation/ModelValidator.py
@@ -37,6 +37,14 @@ class ModelValidator:
         self.index2branch_map = self._create_index_to_branch_map()
         self.branch2node_index_map = self._create_branch_to_node_index_map()
 
+        # Track validation runs and whether errors were detected.
+        self.file_validation_ran = False
+        self.file_validation_errors = False
+        self.file_validation_warnings = False
+        self.graph_validation_ran = False
+        self.graph_validation_errors = False
+        self.graph_validation_warnings = False
+
     def _get_model_df(self, read_base_file=True, read_scenario_files=True):
         files_to_read = []
         if read_base_file:
@@ -137,14 +145,14 @@ class ModelValidator:
     def _create_index_to_branch_map(self):
         return {i: self.model_df[COL.branch].loc[i] for i in self.model_df.index}
 
-    def _raise_concerns(self, concerns: List[object], concern_key: str, concern_desc: str):
+    def _raise_concerns(self, concerns: List[object], concern_key: str, concern_desc: str) -> bool:
         """
         Format and print a single validation result.
 
         Prints the number of issues found, a short description, and (if applicable)
         a pointer to `ModelValidator.warnings[...]`. Messages are wrapped with a
         hanging indent for readability. Nothing unless issues are detected. 
-        Updates `validate_count` when concerns are present.
+        Returns True when concerns are present.
         """
         if len(concerns) <= 0:
             more_info = ""
@@ -161,17 +169,21 @@ class ModelValidator:
                 subsequent_indent=" " * (5 + 1)
             )
             print(wrapped_print)
-            self.issue_flag = 1
+            return True
+        return False
 
-    def _run_check(self, check_function, **kwargs):
+    def _run_check(self, check_function, **kwargs) -> bool:
         # Collect list
         concern_list, concern_desc = check_function(**kwargs)
 
         # Raise Concerns
-        self._raise_concerns(concern_list, check_function.__name__, concern_desc)
+        has_concerns = self._raise_concerns(
+            concern_list, check_function.__name__, concern_desc
+        )
 
         # Return list
         self.warnings[check_function.__name__] = concern_list
+        return has_concerns
 
     def validate(self):
         """
@@ -197,24 +209,28 @@ class ModelValidator:
 
         # ---- Errors ----
         print("\n-- Errors --")
-        self.issue_flag = 0
+        errors_found = False
         for name, spec in REGISTRY.iter(phase=Phase.FILE, severity=Severity.ERROR):
             kwargs = resolve_kwargs(self, spec.argmap, context)
-            self._run_check(spec.fn, **kwargs)
-        if self.issue_flag == 0:
+            errors_found |= self._run_check(spec.fn, **kwargs)
+        self.file_validation_errors = errors_found
+        if not errors_found:
             print("No errors found!")
         
         # ---- Warnings ----
         print("\n-- Warnings --")
-        self.issue_flag = 0
+        warnings_found = False
         for name, spec in REGISTRY.iter(phase=Phase.FILE, severity=Severity.WARNING):
             kwargs = resolve_kwargs(self, spec.argmap, context)
-            self._run_check(spec.fn, **kwargs)
-        if self.issue_flag == 0:
+            warnings_found |= self._run_check(spec.fn, **kwargs)
+        self.file_validation_warnings = warnings_found
+        if not warnings_found:
             print("No warnings found!")
         
         timing = f" (completed in {time.time() - start:.2f}s)"
         print(f"\n=== File validation complete{timing} ===")
+
+        self.file_validation_ran = True
    
     def validate_graph(self):
         """
@@ -227,21 +243,25 @@ class ModelValidator:
         context = {}
         # ---- Errors ----
         print("\n-- Errors --")
-        self.issue_flag = 0
+        errors_found = False
         for name, spec in REGISTRY.iter(phase=Phase.GRAPH, severity=Severity.ERROR):
             kwargs = resolve_kwargs(self, spec.argmap, context)
-            self._run_check(spec.fn, **kwargs)
-        if self.issue_flag == 0:
+            errors_found |= self._run_check(spec.fn, **kwargs)
+        self.graph_validation_errors = errors_found
+        if not errors_found:
             print("No errors found!")
         
         # ---- Warnings ----
         print("\n-- Warnings --")
-        self.issue_flag = 0
+        warnings_found = False
         for name, spec in REGISTRY.iter(phase=Phase.GRAPH, severity=Severity.WARNING):
             kwargs = resolve_kwargs(self, spec.argmap, context)
-            self._run_check(spec.fn, **kwargs)
-        if self.issue_flag == 0:
+            warnings_found |= self._run_check(spec.fn, **kwargs)
+        self.graph_validation_warnings = warnings_found
+        if not warnings_found:
             print("No warnings found!")    
         
         timing = f" (completed in {time.time() - start:.2f}s)"
         print(f"\n=== Completed graph-phase validation{timing} ===")
+
+        self.graph_validation_ran = True

--- a/CIMS/model_validation/__init__.py
+++ b/CIMS/model_validation/__init__.py
@@ -1,1 +1,4 @@
+class ValidationError(Exception):
+    pass
+
 from .ModelValidator import ModelValidator


### PR DESCRIPTION
This change makes validation outcomes explicit and guards `construct_graph()` and `run()` behind successful validation. Note, successful validation means no errors were found (warnings are allowed). 

@brad-griffin, how does this error message look (when trying to run `model.run()`)?

```python
Traceback (most recent call last):
  File "/var/folders/hx/gszxdx_d7mxfb7q5ngv8g9nm3nz7zn/T/marimo_41702/__marimo__cell_94c94a7e-867a-406e-92d0-6c9abeb2d34b_.py", line 2, in <module>
    model.run(equilibrium_threshold=0.05, max_iterations=10, show_warnings=False, print_eq=True)
  File "/Users/jilliana/Documents/Consulting/pyCIMS/cims/CIMS/model.py", line 432, in run
    raise ValidationError(
CIMS.model_validation.ValidationError: CIMS.Model.validate_graph() must be run successfully (no errors) before CIMS.Model.run()
```
