### PR TITLE
feat: add file validation for missing structural parent nodes

### DIFF
--- a/CIMS/model_validation/file_errors.py
+++ b/CIMS/model_validation/file_errors.py
@@ -411,3 +411,33 @@ def base_year_market_share_not_one(validator):
     concern_desc = "nodes whose base year market shares do not sum to 1"
 
     return nodes_with_bad_shares, concern_desc
+
+def no_structural_parent_node_exists(validator):
+    """
+    Identify non-root nodes whose structural parent is missing.
+    """
+    data = validator.model_df
+
+    # All defined branches in the model (base + scenario files)
+    branch_set = set(data[COL.branch].dropna().unique())
+    
+    missing_parent_nodes = []
+    for node in branch_set:
+        # Root never requires a parent
+        if node == validator.root_node:
+            continue
+
+        # Parent is everything before the final dot segment
+        parent = ".".join(node.split(".")[:-1])
+        if not parent:
+            # Top-level node with no parent segment (allowed)
+            continue
+
+        # Flag when the parent node is not defined anywhere in the model
+        if parent not in branch_set:
+            missing_parent_nodes.append((validator.branch2node_index_map[node], node))
+
+    # Keep output ordered by source line/index for readability
+    missing_parent_nodes.sort(key=lambda x: x[0])
+    concern_desc = "nodes are missing a structural parent node"
+    return missing_parent_nodes, concern_desc

--- a/CIMS/model_validation/file_errors.py
+++ b/CIMS/model_validation/file_errors.py
@@ -429,12 +429,8 @@ def no_structural_parent_node_exists(validator):
 
         # Parent is everything before the final dot segment
         parent = ".".join(node.split(".")[:-1])
-        if not parent:
-            # Top-level node with no parent segment (allowed)
-            continue
-
-        # Flag when the parent node is not defined anywhere in the model
-        if parent not in branch_set:
+        # Flag when the parent node is missing or undefined (non-root only)
+        if not parent or parent not in branch_set:
             missing_parent_nodes.append((validator.branch2node_index_map[node], node))
 
     # Keep output ordered by source line/index for readability

--- a/CIMS/model_validation/registry.py
+++ b/CIMS/model_validation/registry.py
@@ -225,6 +225,12 @@ REGISTRY.register("base_year_market_share_not_one", CheckSpec(
     severity=Severity.ERROR,
     argmap={}
 ))
+REGISTRY.register("no_structural_parent_node_exists", CheckSpec(
+    fn=file_errors.no_structural_parent_node_exists,
+    phase=Phase.FILE,
+    severity=Severity.ERROR,
+    argmap={}
+))
 
             
 # ---- Warnings ----


### PR DESCRIPTION
#504 

Added file-phase validation to flag nodes whose structural parent is missing. Implemented `no_structural_parent_node_exists` in `cims/CIMS/model_validation/file_errors.py` and registered it as a FILE-phase error in `cims/CIMS/model_validation/registry.py`. Parent is computed from dot-separated branch paths (same logic as structural edges); root node is excluded. Manual testing performed.
