### PR TITLE
513 need service provide and competition checks

### DIFF
--- a/CIMS/model_validation/file_errors.py
+++ b/CIMS/model_validation/file_errors.py
@@ -35,20 +35,6 @@ def undefined_nodes(validator, providers, requested):
 
     return referenced_unspecified, concern_desc
 
-def nodes_no_provided_service(validator):
-    """
-    Identify any nodes which are specified but do not provide a service.
-    """
-    # Only count node-level service_provide rows (exclude tech-level rows)
-    providers = validator.model_df[
-        (validator.model_df[COL.parameter] == PARAM.service_provide) &
-        (validator.model_df[COL.technology].isna())
-    ][validator.node_col]
-    nodes = get_nodes(validator.model_df, validator.node_col)
-    nodes_no_service = [(i, n) for i, n in nodes.items() if n not in providers.values]
-
-    concern_desc = "nodes are specified but have no 'Service Provide'"
-    return nodes_no_service, concern_desc
 
 def nodes_requesting_self(validator):
     """
@@ -290,34 +276,6 @@ def min_max_conflicts(validator):
 
     return min_max_conflicts, concern_desc
 
-def new_nodes_in_scenario(validator):
-    """
-    Identify new nodes included in the scenario models (i.e. were not in the
-    base model) but which don't have a service provide parameter.
-    """
-    if validator.scenario_files:
-        # The model dataframes
-        base_data = validator._get_model_df(read_scenario_files=False)
-        scenario_data = validator._get_model_df(read_base_file=False)
-
-        # Find nodes from base and scenario files
-        base_nodes = set(base_data[validator.node_col].dropna())
-        scen_nodes = set(scenario_data[validator.node_col].dropna())
-        declared_new_nodes = set(scenario_data[scenario_data[COL.parameter]==PARAM.service_provide]\
-            [validator.node_col].dropna())
-
-        # Find new nodes which haven't been declared without a service provide line
-        new_nodes_in_scenario = list(scen_nodes\
-                                    .difference(declared_new_nodes)\
-                                    .difference(base_nodes))
-    else:
-        new_nodes_in_scenario = []
-
-    # Create Warning information
-    concern_desc = "nodes were included in scenario/model update files without \
-        a Service provide parameter"
-
-    return new_nodes_in_scenario, concern_desc
 
 def new_techs_in_scenario(validator):
     """

--- a/CIMS/model_validation/file_errors.py
+++ b/CIMS/model_validation/file_errors.py
@@ -36,7 +36,11 @@ def nodes_no_provided_service(validator):
     """
     Identify any nodes which are specified but do not provide a service.
     """
-    providers = get_providers(validator.model_df, node_col=validator.node_col)
+    # Only count node-level service_provide rows (exclude tech-level rows)
+    providers = validator.model_df[
+        (validator.model_df[COL.parameter] == PARAM.service_provide) &
+        (validator.model_df[COL.technology].isna())
+    ][validator.node_col]
     nodes = get_nodes(validator.model_df, validator.node_col)
     nodes_no_service = [(i, n) for i, n in nodes.items() if n not in providers.values]
 

--- a/CIMS/model_validation/file_errors.py
+++ b/CIMS/model_validation/file_errors.py
@@ -15,8 +15,11 @@ def invalid_competition_type(validator):
     df = validator.model_df
     valid_competition_list = validator.competition_types
     
-    invalid_rows = df[(df[COL.parameter] == PARAM.competition_type) &
-                      (~df[COL.context].str.lower().isin(valid_competition_list))]
+    comp_rows = df[df[COL.parameter] == PARAM.competition_type]
+    context_str = comp_rows[COL.context].astype(str).str.strip().str.lower()
+    missing_context = comp_rows[COL.context].isna() | context_str.eq("")
+    invalid_context = missing_context | ~context_str.isin(valid_competition_list)
+    invalid_rows = comp_rows[invalid_context]
     invalid_nodes = list(zip(invalid_rows.index, invalid_rows[COL.branch]))
 
     concern_desc = "nodes have an invalid 'Competition Type'"
@@ -442,7 +445,7 @@ def nodes_missing_service_provide(validator):
 
 def nodes_missing_competition(validator):
     """
-    Identify nodes missing a Competition parameter row with a non-empty Context value.
+    Identify nodes missing a Competition parameter row.
     """
     data = validator.model_df
 
@@ -452,10 +455,8 @@ def nodes_missing_competition(validator):
     # All nodes defined in the model
     nodes = set(data[validator.node_col].dropna().unique())
 
-    # Nodes with non-empty Competition values (found in context column)
+    # Nodes with Competition (any context value, including blank)
     competition_rows = node_rows[node_rows[COL.parameter] == PARAM.competition_type]
-    context_str = competition_rows[COL.context].astype(str).str.strip()
-    competition_rows = competition_rows[competition_rows[COL.context].notna() & context_str.ne("")]
     nodes_with_competition = set(competition_rows[validator.node_col].dropna().unique())
 
     missing = []

--- a/CIMS/model_validation/file_errors.py
+++ b/CIMS/model_validation/file_errors.py
@@ -40,7 +40,7 @@ def nodes_no_provided_service(validator):
     nodes = get_nodes(validator.model_df, validator.node_col)
     nodes_no_service = [(i, n) for i, n in nodes.items() if n not in providers.values]
 
-    concern_desc = "nodes are specified but have no 'Service Provided'"
+    concern_desc = "nodes are specified but have no 'Service Provide'"
     return nodes_no_service, concern_desc
 
 def nodes_requesting_self(validator):
@@ -286,7 +286,7 @@ def min_max_conflicts(validator):
 def new_nodes_in_scenario(validator):
     """
     Identify new nodes included in the scenario models (i.e. were not in the
-    base model) but which don't have a service provided parameter.
+    base model) but which don't have a service provide parameter.
     """
     if validator.scenario_files:
         # The model dataframes
@@ -299,7 +299,7 @@ def new_nodes_in_scenario(validator):
         declared_new_nodes = set(scenario_data[scenario_data[COL.parameter]==PARAM.service_provide]\
             [validator.node_col].dropna())
 
-        # Find new nodes which haven't been declared without a service provided line
+        # Find new nodes which haven't been declared without a service provide line
         new_nodes_in_scenario = list(scen_nodes\
                                     .difference(declared_new_nodes)\
                                     .difference(base_nodes))
@@ -308,7 +308,7 @@ def new_nodes_in_scenario(validator):
 
     # Create Warning information
     concern_desc = "nodes were included in scenario/model update files without \
-        a Service provided parameter"
+        a Service provide parameter"
 
     return new_nodes_in_scenario, concern_desc
 
@@ -335,7 +335,7 @@ def new_techs_in_scenario(validator):
                                 scen_declared_techs[[validator.node_col, COL.technology]]\
                                     .dropna().drop_duplicates().values])
 
-        # Find new nodes which haven't been declared without a service provided line
+        # Find new nodes which haven't been declared without a service provide line
         new_techs_in_scenario = list(scen_techs\
                                     .difference(declared_new_techs)\
                                     .difference(base_techs))
@@ -411,3 +411,53 @@ def base_year_market_share_not_one(validator):
     concern_desc = "nodes whose base year market shares do not sum to 1"
 
     return nodes_with_bad_shares, concern_desc
+
+def nodes_missing_service_provide(validator):
+    """
+    Identify nodes missing a Service Provide parameter.
+    """
+    data = validator.model_df
+
+    # Only node-level rows (exclude tech-level rows)
+    node_rows = data[data[COL.technology].isna()]
+
+    # All nodes defined in the model
+    nodes = set(data[validator.node_col].dropna().unique())
+
+    # Nodes with Service Provide
+    service_rows = node_rows[node_rows[COL.parameter] == PARAM.service_provide]
+    nodes_with_service = set(service_rows[validator.node_col].dropna().unique())
+
+    missing = []
+    for node in sorted(nodes):
+        if node not in nodes_with_service:
+            missing.append((validator.branch2node_index_map[node], node))
+
+    concern_desc = "nodes are missing a Service Provide parameter"
+    return missing, concern_desc
+
+def nodes_missing_competition(validator):
+    """
+    Identify nodes missing a Competition parameter row with a non-empty Context value.
+    """
+    data = validator.model_df
+
+    # Only node-level rows (exclude tech-level rows)
+    node_rows = data[data[COL.technology].isna()]
+
+    # All nodes defined in the model
+    nodes = set(data[validator.node_col].dropna().unique())
+
+    # Nodes with non-empty Competition values (found in context column)
+    competition_rows = node_rows[node_rows[COL.parameter] == PARAM.competition_type]
+    context_str = competition_rows[COL.context].astype(str).str.strip()
+    competition_rows = competition_rows[competition_rows[COL.context].notna() & context_str.ne("")]
+    nodes_with_competition = set(competition_rows[validator.node_col].dropna().unique())
+
+    missing = []
+    for node in sorted(nodes):
+        if node not in nodes_with_competition:
+            missing.append((validator.branch2node_index_map[node], node))
+
+    concern_desc = "nodes are missing a Competition parameter"
+    return missing, concern_desc

--- a/CIMS/model_validation/registry.py
+++ b/CIMS/model_validation/registry.py
@@ -123,12 +123,6 @@ REGISTRY.register("invalid_competition_type", CheckSpec(
     severity=Severity.ERROR,
     argmap={},
 ))
-REGISTRY.register("nodes_no_provided_service", CheckSpec(
-    fn=file_errors.nodes_no_provided_service,
-    phase=Phase.FILE,
-    severity=Severity.ERROR,
-    argmap={}
-))
 REGISTRY.register("nodes_requesting_self", CheckSpec(
     fn=file_errors.nodes_requesting_self,
     phase=Phase.FILE,
@@ -203,12 +197,6 @@ REGISTRY.register("both_cop_p2000_defined", CheckSpec(
 ))
 REGISTRY.register("min_max_conflicts", CheckSpec(
     fn=file_errors.min_max_conflicts,
-    phase=Phase.FILE,
-    severity=Severity.ERROR,
-    argmap={}
-))
-REGISTRY.register("new_nodes_in_scenario", CheckSpec(
-    fn=file_errors.new_nodes_in_scenario,
     phase=Phase.FILE,
     severity=Severity.ERROR,
     argmap={}

--- a/CIMS/model_validation/registry.py
+++ b/CIMS/model_validation/registry.py
@@ -225,6 +225,18 @@ REGISTRY.register("base_year_market_share_not_one", CheckSpec(
     severity=Severity.ERROR,
     argmap={}
 ))
+REGISTRY.register("nodes_missing_service_provide", CheckSpec(
+    fn=file_errors.nodes_missing_service_provide,
+    phase=Phase.FILE,
+    severity=Severity.ERROR,
+    argmap={}
+))
+REGISTRY.register("nodes_missing_competition", CheckSpec(
+    fn=file_errors.nodes_missing_competition,
+    phase=Phase.FILE,
+    severity=Severity.ERROR,
+    argmap={}
+))
 
             
 # ---- Warnings ----


### PR DESCRIPTION
#513 
 
## Summary
- Added a file‑phase error check that flags any branch missing a **node‑level** `service_provide` row (`nodes_missing_service_provide`).
- Added a file‑phase error check that flags any branch missing a **node‑level** `competition` row (`nodes_missing_competition`).
- Updated `invalid_competition_type` to also flag **blank/None** competition context values (per #510 intent).
- Removed redundant checks and definitions: `nodes_no_provided_service` and `new_nodes_in_scenario`.

## Behavior Details
- **Service Provided**
  - A branch must have a row where `Parameter = service_provide` and `Technology` is empty. (`nodes_missing_service_provide`)
- **Competition**
  - A branch must have a row where `Parameter = competition` and `Technology` is empty (`nodes_missing_competition`).
  - Any competition row (node‑ or tech‑level) with blank/None `Context` is now considered invalid (`invalid_competition_type`).

## Testing
- Manual checks only:
  - Verified `nodes_missing_service_provide` flags nodes missing node‑level `service_provide`.
  - Verified `nodes_missing_competition` flags nodes missing node‑level `competition` row.
  - Verified `invalid_competition_type` flags blank/None context values.