### PR TITLE
550 Fix pandas version to 2.3.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     'numpy',
     'polars',
     'pyarrow',
-    'pandas>=1.2',
+    'pandas==2.3.3',
     'xlrd',
     'pyxlsb',
     'scipy',


### PR DESCRIPTION
Pandas 3.0.0 introduces breaking changes that destroy the nested dictionary structure of the node data in the graph. This PR fixes the pandas version to 2.3.3 (the most recent pandas version before the breaking change) in the `pyproject.toml` file.