### PR TITLE
Add `target` argument to `get_param` (#455)

### DIFF
--- a/src/CIMS/aggregation/cumulative_emissions_aggregation.py
+++ b/src/CIMS/aggregation/cumulative_emissions_aggregation.py
@@ -158,7 +158,7 @@ def _find_cumulative_rate_via_request_provide_edge(model, agg_info, year, cumula
 
     emission_rates = base_emissions_class()
 
-    req_ratio = model.get_param(PARAM.service_request, parent_node, year, tech=parent_tech, context=child_node)
+    req_ratio = model.get_param(PARAM.service_request, parent_node, year, tech=parent_tech, target=child_node)
     # If the child produces emissions (e.g. requests supply with emissions), we
     # multiply the child's direct emission rate by the service_request ratio.
     direct_emission_rate_param = cumulative_rate_param.replace('cumul_', 'direct_')

--- a/src/CIMS/lcc_calculation.py
+++ b/src/CIMS/lcc_calculation.py
@@ -464,12 +464,12 @@ def calc_financial_annual_service_cost(model: 'CIMS.Model', node: str, year: str
     def do_sc_calculation(target):
         service_requested_value = calculate_vintage_weighted_parameter(PARAM.service_request,
                                                                        model, node, year,
-                                                                       tech=tech, context=target)
+                                                                       tech=tech, target=target)
         service_cost = 0
 
         if target in model.supply_nodes:
             supply_price = model.get_param(PARAM.price, target, year, do_calc=True)
-            multiplier_price = model.get_param(PARAM.multiplier_price, node, year, context=target)
+            multiplier_price = model.get_param(PARAM.multiplier_price, node, year, target=target)
             service_requested_price = supply_price * multiplier_price
 
         else:
@@ -514,12 +514,12 @@ def calc_competition_annual_service_cost(model: 'CIMS.Model', node: str, year: s
     """
 
     def do_sc_calculation(target):
-        service_requested_value = model.get_param(PARAM.service_request, node, year, tech=tech, context=target)
+        service_requested_value = model.get_param(PARAM.service_request, node, year, tech=tech, target=target)
         service_cost = 0
 
         if target in model.supply_nodes:
             supply_price = model.get_param(PARAM.price, target, year, do_calc=True)
-            multiplier_price = model.get_param(PARAM.multiplier_price, node, year, context=target)
+            multiplier_price = model.get_param(PARAM.multiplier_price, node, year, target=target)
             service_requested_price = supply_price * multiplier_price
 
         else:

--- a/src/CIMS/model.py
+++ b/src/CIMS/model.py
@@ -1102,7 +1102,8 @@ class Model:
         return self.node_tech_defaults[parameter]
 
     def get_param(self, param, node, year=None, tech=None, context=None, sub_context=None,
-                  return_source=False, do_calc=False, check_exist=False, dict_expected=False):
+                  target=None, return_source=False, do_calc=False, check_exist=False,
+                  dict_expected=False):
         """
         Gets a parameter's value from the model, given a specific context (node,
         year, tech, context, sub-context), calculating the parameter's value if
@@ -1127,17 +1128,21 @@ class Model:
             cannot change year to year (e.g. competition type).
         tech : str, optional
             The name of the technology you are interested in. `tech` is not
-            required for parameters that are specified at the node level. 
-            `tech` is required to get any parameter that is stored within a 
+            required for parameters that are specified at the node level.
+            `tech` is required to get any parameter that is stored within a
             technology.
         context : str, optional
-            Used when there is context available in the node. Analogous to the 
+            Used when there is context available in the node. Analogous to the
             `context` column in the model description
         sub_context : str, optional
-            Must be used only if context is given. Analogous to the 
+            Must be used only if context is given. Analogous to the
             `sub_context` column in the model description
+        target : str, optional
+            A target node name used to differentiate values for the same
+            parameter across multiple service request lines. Applied as a dict
+            key lookup after `context`/`sub_context`.
         return_source : bool, default=False
-            Whether or not to return the method by which this value was 
+            Whether or not to return the method by which this value was
             originally obtained.
         do_calc : bool, default=False
             If False, the function will only retrieve the value using the
@@ -1159,7 +1164,7 @@ class Model:
             `year` and `tech`.
         str :
             If return_source is `True`, returns a string indicating how the
-            parameter's value was originally obtained {model, initialization, 
+            parameter's value was originally obtained {model, initialization,
             inheritance, calculation, default, or previous_year}.
         """
 
@@ -1167,6 +1172,7 @@ class Model:
                                     tech=tech,
                                     context=context,
                                     sub_context=sub_context,
+                                    target=target,
                                     return_source=return_source,
                                     do_calc=do_calc,
                                     check_exist=check_exist,

--- a/src/CIMS/stock_allocation/stock_allocation.py
+++ b/src/CIMS/stock_allocation/stock_allocation.py
@@ -766,7 +766,7 @@ def _record_provided_quantities(model, node, year, requested_services, assessed_
 
     for target in requested_services:
         vintage_weighted_service_request_ratio = calculate_vintage_weighted_parameter(
-            PARAM.service_request, model, node, year, tech=tech, context=target)
+            PARAM.service_request, model, node, year, tech=tech, target=target)
         quant_requested = market_share_total * vintage_weighted_service_request_ratio * assessed_demand
         year_node = model.graph.nodes[target][year]
         if PARAM.provided_quantities not in year_node.keys():

--- a/src/CIMS/utils/graph/query.py
+++ b/src/CIMS/utils/graph/query.py
@@ -130,7 +130,7 @@ def get_services_requested(model, node, year, tech=None, use_vintage_weighting=F
             if use_vintage_weighting:
                 weighted_services = {}
                 for target in services_requested:
-                    weighted_req_ratio = vintage_weighting.calculate_vintage_weighted_parameter(PARAM.service_request, model, node, year, tech=tech, context=target)
+                    weighted_req_ratio = vintage_weighting.calculate_vintage_weighted_parameter(PARAM.service_request, model, node, year, tech=tech, target=target)
                     weighted_services[target] = create_value_dict(year_val=weighted_req_ratio, target=target, param_source='vintage_weighting')
                 services_requested = weighted_services
 

--- a/src/CIMS/utils/parameter/query.py
+++ b/src/CIMS/utils/parameter/query.py
@@ -25,7 +25,8 @@ calculation_directory = {
 }
 
 def get_param(model, param, node, year=None, tech=None, context=None, sub_context=None,
-              return_source=False, do_calc=False, check_exist=False, dict_expected=False):
+              target=None, return_source=False, do_calc=False, check_exist=False,
+              dict_expected=False):
     """
     Gets a parameter's value from the model, given a specific context (node, year, tech, context, sub-context),
     calculating the parameter's value if needed.
@@ -54,6 +55,12 @@ def get_param(model, param, node, year=None, tech=None, context=None, sub_contex
         Used when there is context available in the node. Analogous to the `context` column in the model description
     sub_context : str, optional
         Must be used only if context is given. Analogous to the `subcontext` column in the model description
+    target : str, optional
+        A target node name used to differentiate values for the same parameter across multiple
+        service request lines (e.g. a node requesting services from several target nodes). Applied
+        as a dict key lookup after `context`/`sub_context`. Can be combined with `context` for
+        chained lookups, or used alone as an alternative to `context` when the dict keys are
+        target node names rather than model-description context values.
     return_source : bool, default=False
         Whether to return the method by which this value was originally obtained.
     do_calc : bool
@@ -102,7 +109,12 @@ def get_param(model, param, node, year=None, tech=None, context=None, sub_contex
                             val = None
                 except KeyError:
                     val = None
-            elif None in val:
+            if target and isinstance(val, dict):
+                try:
+                    val = val[target]
+                except KeyError:
+                    val = None
+            if not context and not target and isinstance(val, dict) and None in val:
                 val = val[None]
 
     # Grab the year_value in the dictionary if exists
@@ -120,6 +132,7 @@ def get_param(model, param, node, year=None, tech=None, context=None, sub_contex
                 \nYear: {year if year else ''}\
                 \nContext: {context if context else ''}\
                 \nSub-context: {sub_context if sub_context else ''}\
+                \nTarget: {target if target else ''}\
                 \nTech: {tech if tech else ''}"
 
         warnings.warn(warning_message)
@@ -158,7 +171,8 @@ def get_param(model, param, node, year=None, tech=None, context=None, sub_contex
         if tech:
             try:
                 val, source = model.get_param(param, node, year=year, context=context,
-                                              sub_context=sub_context, return_source=True)
+                                              sub_context=sub_context, target=target,
+                                              return_source=True)
                 assert (source in ['inheritance', 'model', 'default'])
                 assert (val is not None)
                 param_source = source
@@ -173,6 +187,8 @@ def get_param(model, param, node, year=None, tech=None, context=None, sub_contex
                     val = val[context]
                     if sub_context:
                         val = val[sub_context]
+                if target and isinstance(val, dict):
+                    val = val[target]
                 if val[PARAM.param_source] == 'inheritance':
                     param_source = 'inheritance'
             except KeyError:
@@ -197,6 +213,7 @@ def get_param(model, param, node, year=None, tech=None, context=None, sub_contex
                                       year=prev_year,
                                       context=context,
                                       sub_context=sub_context,
+                                      target=target,
                                       tech=tech,
                                       dict_expected=dict_expected)
                 param_source = 'previous_year'

--- a/src/CIMS/vintage_weighting.py
+++ b/src/CIMS/vintage_weighting.py
@@ -49,7 +49,8 @@ def _get_vintage_weights(model, node, year, tech):
 
 
 def calculate_vintage_weighted_parameter(parameter: str, model: "CIMS.Model", node: str,
-                                         year: str, tech: str, context: str = None, default_value=0) -> float:
+                                         year: str, tech: str, context: str = None,
+                                         target: str = None, default_value=0) -> float:
     """
     Uses vintage-based weighting to calculate the value of a parameter. This function is used for
     peforming vintage-based weighting of financial LCC and quantities requested of children nodes.
@@ -74,6 +75,8 @@ def calculate_vintage_weighted_parameter(parameter: str, model: "CIMS.Model", no
         vintage-weighted value.
     tech : The name of the technology whose vintage-weighted parameter value will be calculated
     context : Optional. The additional context needed to access the parameter value of interest.
+    target : Optional. A target node name used to differentiate values for the same parameter
+        across multiple service request lines.
 
     Returns
     -------
@@ -86,7 +89,8 @@ def calculate_vintage_weighted_parameter(parameter: str, model: "CIMS.Model", no
 
     weighted_parameter = default_value
     for vintage_year, weight in vintage_weights.items():
-        parameter_value = model.get_param(parameter, node, vintage_year, tech=tech, context=context)
+        parameter_value = model.get_param(parameter, node, vintage_year, tech=tech,
+                                          context=context, target=target)
         weighted_parameter += parameter_value * weight
 
     return weighted_parameter


### PR DESCRIPTION
## Summary

Adds a dedicated `target` parameter to `get_param`, `Model.get_param`, and `calculate_vintage_weighted_parameter`, replacing the `context=target` workaround that was previously used to differentiate parameter values across multiple service request lines.

## Background
When a node has multiple service request lines (e.g. requesting services from several target nodes), the same parameter is stored as a dict keyed by target node names. Previously, callers worked around this by passing the target node as `context=target` — which is meant to correspond to the `context` column in the model description.

## Changes
- `target` is applied as a dict-key lookup after `context`/`sub_context`, so it can be used alone or chained with `context`
- The `None`-key fallback only fires when neither `context` nor `target` is provided (preserving existing behaviour)
- `target` is threaded through all recursive paths in `get_param` (tech-inheritance and previous-year fallback)
- Updated 7 call sites across `lcc_calculation.py`, `stock_allocation.py`, `utils/graph/query.py`, `vintage_weighting.py`, and
  `aggregation/cumulative_emissions_aggregation.py`

## Notes
- All existing `context=` usages (e.g. `context=ghg`, `context=region`, `context=ms_class`) are unaffected
- Closes #455
