### PR TITLE
570 constant values

### DIFF
--- a/src/CIMS/model_validation/file_errors.py
+++ b/src/CIMS/model_validation/file_errors.py
@@ -24,11 +24,11 @@ def invalid_competition_type(validator):
 
     df = validator.model_df
     comp_rows = df[df[COL.parameter] == PARAM.competition_type]
-    context_str = comp_rows[COL.context].astype(str).str.strip().str.lower()
+    value_str = comp_rows[COL.value].astype(str).str.strip().str.lower()
     missing_or_invalid = (
-        comp_rows[COL.context].isna()
-        | context_str.eq("")
-        | ~context_str.isin(validator.competition_types)
+        comp_rows[COL.value].isna()
+        | value_str.eq("")
+        | ~value_str.isin(validator.competition_types)
     )
 
     invalid_rows = comp_rows[missing_or_invalid]
@@ -98,16 +98,16 @@ def supply_without_lcc_or_price(validator):
     Aggregation nodes with competition = Sector are excluded: they derive
     their base-year price from children and do not need a direct price row.
     """
-    # Supply nodes: is_supply parameter with context == "True"
+    # Supply nodes: is_supply parameter with value == "True"
     supply_nodes = validator.model_df[
         validator.model_df[COL.parameter].str.contains(PARAM.is_supply, case=False, na=False) &
-        (validator.model_df[COL.context].str.lower() == "true")
+        (validator.model_df[COL.value].str.lower() == "true")
     ][COL.branch]
 
     # Aggregation nodes (competition = Sector) derive price from children — skip them
     sector_nodes = validator.model_df[
         (validator.model_df[COL.parameter] == PARAM.competition_type) &
-        (validator.model_df[COL.context].str.lower() == "sector")
+        (validator.model_df[COL.value].str.lower() == "sector")
     ][COL.branch]
     supply_nodes = supply_nodes[~supply_nodes.isin(sector_nodes)]
 
@@ -162,7 +162,7 @@ def tech_compete_nodes_no_techs(validator):
 
     # Find all Tech Compete Nodes
     tech_compete_nodes = data[(data[COL.parameter].str.lower().str.contains(PARAM.competition_type)) &
-                              (data[COL.context].str.lower().str.contains(PARAM.competition_compete))][validator.node_col]
+                              (data[COL.value].str.lower().str.contains(PARAM.competition_compete))][validator.node_col]
 
     # Find all Technology Header Rows
     techs = data[data[COL.parameter] == COL.technology.lower()]
@@ -273,7 +273,7 @@ def service_req_at_tech_node(validator):
 
     # Find all Tech compete nodes
     tech_nodes = data[(data[COL.parameter]==PARAM.competition_type) &
-                      (data[COL.context].str.lower().str.contains(PARAM.competition_compete))][validator.node_col].unique()
+                      (data[COL.value].str.lower().str.contains(PARAM.competition_compete))][validator.node_col].unique()
 
 
     # Find service request rows specified at the node level of a [node-]tech
@@ -362,7 +362,7 @@ def lcc_at_tech_node(validator):
     """
     Identify any tech-compete nodes where an LCC value has been set exogenously.
     """
-    tech_nodes = validator.model_df[COL.branch][(validator.model_df[COL.parameter] == PARAM.competition_type) & (validator.model_df[COL.context].str.lower().str.contains(PARAM.competition_compete))]
+    tech_nodes = validator.model_df[COL.branch][(validator.model_df[COL.parameter] == PARAM.competition_type) & (validator.model_df[COL.value].str.lower().str.contains(PARAM.competition_compete))]
     lcc_nodes = validator.model_df[COL.branch][
         validator.model_df[COL.technology].isna() &
         validator.model_df[COL.parameter].str.lower().str.contains('lcc')]

--- a/src/CIMS/model_validation/registry.py
+++ b/src/CIMS/model_validation/registry.py
@@ -130,7 +130,7 @@ REGISTRY.register("invalid_competition_type", CheckSpec(
         "  Each entry is a node whose competition parameter is blank or not in the\n"
         "  valid competition types list; row_index is that node's competition row\n"
         "  in model_df, node is the branch name.\n\n"
-        "Reading: check the Context column at the flagged row to see what value was\n"
+        "Reading: check the Value column at the flagged row to see what value was\n"
         "set. This check is skipped entirely when no list CSV is provided."
     ),
 ))

--- a/src/CIMS/utils/graph/node_utils.py
+++ b/src/CIMS/utils/graph/node_utils.py
@@ -141,12 +141,23 @@ def _add_all_year_data(graph, current_node_df, current_node, year_list=None):
             if year not in graph.nodes[current_node]:
                 graph.nodes[current_node][year] = {}
 
-    years_with_data = current_node_df["Year"].dropna().unique()
-    for year in years_with_data:
-        year_df = current_node_df[current_node_df["Year"] == year].drop(columns=["Year"])
-        existing_year_dict = _get_current_year_dict(graph, current_node, year)
-        updated_year_dict = _update_year_dict(existing_year_dict, [year_df[c] for c in year_df.columns])
-        graph.nodes[current_node][year] = updated_year_dict
+    # Constant rows (null Year, non-null Value) seed every year; year-specific rows override.
+    is_constant = current_node_df[COL.year].isna() & current_node_df[COL.value].notna()
+    constant_df = current_node_df[is_constant].drop(columns=[COL.year])
+
+    if not constant_df.empty:
+        seed = [constant_df[c] for c in constant_df.columns]
+        for year in (year_list or sorted(current_node_df[COL.year].dropna().unique())):
+            graph.nodes[current_node][year] = _update_year_dict(
+                _get_current_year_dict(graph, current_node, year), seed
+            )
+
+    for year in current_node_df[COL.year].dropna().unique():
+        year_df = current_node_df[current_node_df[COL.year] == year].drop(columns=[COL.year])
+        graph.nodes[current_node][year] = _update_year_dict(
+            _get_current_year_dict(graph, current_node, year),
+            [year_df[c] for c in year_df.columns]
+        )
 
     return graph, current_node_df
 
@@ -193,10 +204,10 @@ def _standardize_param_value(val):
 
 
 def _add_node_constant(graph, node_df, node, parameter, required=False):
-    parameter_list = list(node_df[node_df[COL.parameter] == parameter][COL.context])
+    parameter_list = list(node_df[node_df[COL.parameter] == parameter][COL.value])
 
     if len(set(parameter_list)) == 1:
-        parameter_val = _standardize_param_value(parameter_list[0])
+        parameter_val = infer_type(_standardize_param_value(parameter_list[0]))
     elif len(set(parameter_list)) > 1:
         raise ValueError(f"{parameter} has too many values at {node}.")
     elif parameter in graph.nodes[node]:
@@ -294,21 +305,33 @@ def _add_node_data(graph, current_node, node_dfs, year_list=None):
     return graph
 
 
-def _add_all_year_data_for_tech(graph, current_tech_df, node, current_tech):
-    years = current_tech_df["Year"].dropna().unique()
-    for year in years:
-        year_df = current_tech_df[current_tech_df["Year"] == year].drop(columns=["Year"])
-        existing_year_dict = _get_current_year_dict(graph, node, year, tech=current_tech)
-        updated_year_dict = _update_year_dict(existing_year_dict, [year_df[c] for c in year_df.columns])
+def _add_all_year_data_for_tech(graph, current_tech_df, node, current_tech, year_list=None):
+    # Constant rows (null Year, non-null Value) seed every year; year-specific rows override.
+    is_constant = current_tech_df[COL.year].isna() & current_tech_df[COL.value].notna()
+    constant_df = current_tech_df[is_constant].drop(columns=[COL.year])
 
-        # Add technologies key to the node's year dict if needed
+    if not constant_df.empty and year_list:
+        seed = [constant_df[c] for c in constant_df.columns]
+        for year in year_list:
+            updated = _update_year_dict(_get_current_year_dict(graph, node, year, tech=current_tech), seed)
+            if PARAM.technologies not in graph.nodes[node][year]:
+                graph.nodes[node][year][PARAM.technologies] = {}
+            graph.nodes[node][year][PARAM.technologies][current_tech] = updated
+            if PARAM.tree_index not in updated:
+                updated[PARAM.tree_index] = int(current_tech_df.index[0]) + graph.cur_tree_index[0]
+
+    for year in current_tech_df[COL.year].dropna().unique():
+        year_df = current_tech_df[current_tech_df[COL.year] == year].drop(columns=[COL.year])
+        updated = _update_year_dict(_get_current_year_dict(graph, node, year, tech=current_tech),
+                                    [year_df[c] for c in year_df.columns])
+
         if PARAM.technologies not in graph.nodes[node][year]:
             graph.nodes[node][year][PARAM.technologies] = {}
 
-        graph.nodes[node][year][PARAM.technologies][current_tech] = updated_year_dict
+        graph.nodes[node][year][PARAM.technologies][current_tech] = updated
 
-        if PARAM.tree_index not in graph.nodes[node][year][PARAM.technologies][current_tech]:
-            graph.nodes[node][year][PARAM.technologies][current_tech][PARAM.tree_index] = int(current_tech_df.index[0]) + graph.cur_tree_index[0]
+        if PARAM.tree_index not in updated:
+            updated[PARAM.tree_index] = int(current_tech_df.index[0]) + graph.cur_tree_index[0]
 
     return graph, current_tech_df
 
@@ -319,7 +342,7 @@ def _init_tech(graph, current_tech_df):
     return graph, current_tech_df
 
 
-def _add_tech_data(graph, node, tech_dfs, current_tech):
+def _add_tech_data(graph, node, tech_dfs, current_tech, year_list=None):
     """
     Add and populate a new technology to `node`'s data within`graph`
     Parameters
@@ -328,6 +351,9 @@ def _add_tech_data(graph, node, tech_dfs, current_tech):
         The name of the node the new technology data will reside in.
     tech : str
         The name of the technology being added to the graph.
+    year_list : list of str, optional
+        All years the model is being run for. Required for constant rows
+        (null Year, non-null Value) to be seeded across every year.
     Returns
     -------
     networkx.Graph
@@ -341,9 +367,8 @@ def _add_tech_data(graph, node, tech_dfs, current_tech):
     graph, current_tech_df = _init_tech(graph, current_tech_df)
 
     # 3 Group data by year & add to the tech's dictionary
-    # NOTE: This is very similar to what we do for nodes (above). However, it differs because
-    # we aren't using the value column (its redundant here). TODO: Check
-    graph, current_tech_df = _add_all_year_data_for_tech(graph, current_tech_df, node, current_tech)
+    graph, current_tech_df = _add_all_year_data_for_tech(graph, current_tech_df, node, current_tech,
+                                                          year_list=year_list)
 
     # 4 Return the new graph
     return graph
@@ -397,7 +422,7 @@ def make_or_update_nodes(graph, node_dfs, tech_dfs, year_list=None):
     # 4 Add technologies to the graph
     for node in tech_dfs:
         for tech in tech_dfs[node]:
-            new_graph = _add_tech_data(graph, node, tech_dfs, tech)
+            new_graph = _add_tech_data(graph, node, tech_dfs, tech, year_list=year_list)
 
     # Return the graph
     return new_graph

--- a/src/CIMS/utils/graph/node_utils.py
+++ b/src/CIMS/utils/graph/node_utils.py
@@ -121,11 +121,12 @@ def _update_year_dict(existing_year_dict, update_data):
                     ((param in existing_year_dict) and (PARAM.year_value not in existing_year_dict[param])):
                     year_dict[param][context] = value_dict
 
-                # 3. We save context as the year_value, which will remain constant
-                #    across all years.
+                # 3. Context present but Value null — old format no longer supported.
                 else:
-                    value_dict[PARAM.year_value] = infer_type(context)
-                    year_dict[param] = value_dict
+                    raise ValueError(
+                        f"Parameter '{param}' has a Context value ('{context}') but no Value. "
+                        "Constants must use the Value column with a null Year."
+                    )
             else:
                 year_dict[param] = value_dict
 

--- a/src/CIMS/utils/model_description/column_list.py
+++ b/src/CIMS/utils/model_description/column_list.py
@@ -9,6 +9,8 @@ context = "Context"
 sub_context = "Sub_Context"
 target = "Target"
 unit = "Unit"
+year = "Year"
+value = "Value"
 node = "Node"
 
 # ------------ Default Parameters CSVs ------------ #


### PR DESCRIPTION
Closes #570 

## Summary
- Constants in model input CSVs (`competition`, `is_supply`, `aggregate_structural`) now store their value in the `Value` column with a null `Year`, replacing the old pattern of storing values in the `Context` column. `Context` is now reserved exclusively for contextual specificity (e.g. differentiating GHG types for `emissions_gwp`).
- Year-independent parameters (`available`, `fcc`, `lifetime`, `discount_rate_financial`, etc.) are now seeded to every year dict during graph construction, making them accessible via `get_param()` at all model years.
- Year-specific values override constants for any year where both are provided. In the scenario update pattern, a scenario constant overrides all base model year-specific values for that parameter.
- Node-level constants (`competition`, `is_supply`, `aggregate_structural`) are now type-coerced via `infer_type`, so boolean values are stored as Python `bool` rather than strings.
- The old context-as-value pattern now raises a `ValueError` at graph build time rather than silently misbehaving.
- All validator checks that previously read `competition` and `is_supply` from the `Context` column are updated to read from `Value`.
