### PR TITLE
399 currency conversion

### DIFF
--- a/scenarios/Net Zero.py
+++ b/scenarios/Net Zero.py
@@ -311,6 +311,9 @@ def _(
     year_list,
 ):
     #################### Instantiate Model ####################
+    # Once currency_deflator.csv and currency_exchange.csv are available in
+    # data/model_inputs/, uncomment target_units/deflator_path/exchange_path below
+    # to normalize cost inputs to a single currency and dollar-year.
     model = CIMS.Model(
         model_path=model_path,
         base_model=base_model,
@@ -320,6 +323,9 @@ def _(
         sector_list=sector_list,
         default_values_csv_path=default_path,
         list_csv_path=list_path,
+        # target_units={"currency": "CAD", "dollar_year": 2020},
+        # deflator_path="data/model_inputs/currency_deflator.csv",
+        # exchange_path="data/model_inputs/currency_exchange.csv",
     )
     return (model,)
 

--- a/scenarios/Reference.py
+++ b/scenarios/Reference.py
@@ -311,6 +311,9 @@ def _(
     update_files,
     year_list,
 ):
+    # Once currency_deflator.csv and currency_exchange.csv are available in
+    # data/model_inputs/, uncomment target_units/deflator_path/exchange_path below
+    # to normalize cost inputs to a single currency and dollar-year.
     model = CIMS.Model(
         model_path=model_path,
         base_model= base_model,
@@ -320,6 +323,9 @@ def _(
         sector_list=sector_list,
         default_values_csv_path=default_path,
         list_csv_path=list_path,
+        # target_units={"currency": "CAD", "dollar_year": 2020},
+        # deflator_path="data/model_inputs/currency_deflator.csv",
+        # exchange_path="data/model_inputs/currency_exchange.csv",
     )
     return (model,)
 

--- a/src/CIMS/model.py
+++ b/src/CIMS/model.py
@@ -256,16 +256,22 @@ class Model:
         graph.max_tree_index = [0]
 
         node_dfs, tech_dfs = self.node_dfs, self.tech_dfs
+        scenario_node_dfs = self.scenario_node_dfs
+        scenario_tech_dfs = self.scenario_tech_dfs
         if self.currency_converter is not None:
             print(f"  Converting costs to {self.target_dollar_year}_{self.target_currency}...")
             node_dfs, tech_dfs = apply_currency_conversion(
                 node_dfs, tech_dfs, self.currency_converter,
                 self.target_currency, self.target_dollar_year,
             )
+            scenario_node_dfs, scenario_tech_dfs = apply_currency_conversion(
+                scenario_node_dfs, scenario_tech_dfs, self.currency_converter,
+                self.target_currency, self.target_dollar_year,
+            )
 
         print("  Building base graph...")
         graph = node_utils.make_or_update_nodes(graph, node_dfs, tech_dfs)
-        graph = edge_utils.make_or_update_edges(graph, self.node_dfs, self.tech_dfs)
+        graph = edge_utils.make_or_update_edges(graph, node_dfs, tech_dfs)
         graph.cur_tree_index[0] += graph.max_tree_index[0]
 
         # Update metadata from base graph
@@ -292,10 +298,10 @@ class Model:
             print("  Applying scenario overlays...")
             self.graph.max_tree_index[0] = 0
             graph = node_utils.make_or_update_nodes(
-                self.graph, self.scenario_node_dfs, self.scenario_tech_dfs
+                self.graph, scenario_node_dfs, scenario_tech_dfs
             )
             graph = edge_utils.make_or_update_edges(
-                graph, self.scenario_node_dfs, self.scenario_tech_dfs
+                graph, scenario_node_dfs, scenario_tech_dfs
             )
             self.graph.cur_tree_index[0] += self.graph.max_tree_index[0]
             self.graph = graph

--- a/src/CIMS/model.py
+++ b/src/CIMS/model.py
@@ -26,6 +26,7 @@ from .readers.model_reader import ModelReader
 from .model_validation import ModelValidator, ValidationError
 from .quantities import ProvidedQuantity
 from .emissions import EmissionsCost
+from .unit_conversion import CurrencyConverter, apply_currency_conversion
 
 
 
@@ -68,6 +69,9 @@ class Model:
         sector_list: Iterable[str],
         default_values_csv_path: str,
         list_csv_path: str,
+        target_units: dict = None,
+        deflator_path: str = None,
+        exchange_path: str = None,
         ):
         print("\n=== Instantiating Model ===")
         start_init = time.time()
@@ -154,13 +158,22 @@ class Model:
             ]
         )
 
+        # Currency conversion — configured at instantiation so the validator can access
+        # the tables during validate_files(); conversion is applied later in construct_graph()
+        self.currency_converter = None
+        self.target_currency = None
+        self.target_dollar_year = None
+        if target_units is not None:
+            print("  Configuring currency conversion...")
+            self._configure_currency_conversion(target_units, deflator_path, exchange_path)
+
         # Track current state of the model build
         self.status = "instantiated"  # description loaded, graph not yet constructed
         self.scenario_model_description_file = self._scenario_reader.csv_files
 
         print(f"=== Model instantiation complete (completed in {time.time() - start_init:.2f}s) ===")
 
-    def validate_files(self):            
+    def validate_files(self):
         self.validator.validate()
         
     def validate_graph(self):
@@ -218,6 +231,11 @@ class Model:
 
         return model
 
+    def _configure_currency_conversion(self, target_units: dict, deflator_path: str, exchange_path: str):
+        self.target_currency = target_units["currency"]
+        self.target_dollar_year = target_units["dollar_year"]
+        self.currency_converter = CurrencyConverter(deflator_path, exchange_path)
+
     def construct_graph(self):
         """
         Build the model graph from the base and scenario descriptions and
@@ -231,13 +249,22 @@ class Model:
 
         start = time.time()
         print("\n=== Constructing model graph ===")
-        
+
         # --- Base graph from model description -------------------------------
         graph = nx.DiGraph()
         graph.cur_tree_index = [0]
         graph.max_tree_index = [0]
 
-        graph = node_utils.make_or_update_nodes(graph, self.node_dfs, self.tech_dfs)
+        node_dfs, tech_dfs = self.node_dfs, self.tech_dfs
+        if self.currency_converter is not None:
+            print(f"  Converting costs to {self.target_dollar_year}_{self.target_currency}...")
+            node_dfs, tech_dfs = apply_currency_conversion(
+                node_dfs, tech_dfs, self.currency_converter,
+                self.target_currency, self.target_dollar_year,
+            )
+
+        print("  Building base graph...")
+        graph = node_utils.make_or_update_nodes(graph, node_dfs, tech_dfs)
         graph = edge_utils.make_or_update_edges(graph, self.node_dfs, self.tech_dfs)
         graph.cur_tree_index[0] += graph.max_tree_index[0]
 
@@ -253,7 +280,6 @@ class Model:
         # Initialize parameters on the base graph
         self._inherit_parameter_values()
         self._initialize_tax()
-        print("  Base graph constructed")
 
         # --- Apply scenario overlays (if any) --------------------------------
         if not isinstance(self._scenario_reader, ScenarioReader):
@@ -263,6 +289,7 @@ class Model:
 
         # Only do work if there is scenario content
         if self.scenario_node_dfs or self.scenario_tech_dfs:
+            print("  Applying scenario overlays...")
             self.graph.max_tree_index[0] = 0
             graph = node_utils.make_or_update_nodes(
                 self.graph, self.scenario_node_dfs, self.scenario_tech_dfs
@@ -284,10 +311,9 @@ class Model:
             # Re-initialize parameters after scenario changes
             self._inherit_parameter_values()
             self._initialize_tax()
-            print("  Scenario overlays applied")
 
         else:
-            print("  No scenario overlays to apply")
+            print("  No scenario overlays to apply...")
 
         # Final state after graph is ready
         self.status = "graph constructed"
@@ -1102,8 +1128,8 @@ class Model:
         return self.node_tech_defaults[parameter]
 
     def get_param(self, param, node, year=None, tech=None, context=None, sub_context=None,
-                  target=None, return_source=False, do_calc=False, check_exist=False,
-                  dict_expected=False):
+                  target=None, return_source=False, return_unit=False, do_calc=False,
+                  check_exist=False, dict_expected=False):
         """
         Gets a parameter's value from the model, given a specific context (node,
         year, tech, context, sub-context), calculating the parameter's value if
@@ -1174,6 +1200,7 @@ class Model:
                                     sub_context=sub_context,
                                     target=target,
                                     return_source=return_source,
+                                    return_unit=return_unit,
                                     do_calc=do_calc,
                                     check_exist=check_exist,
                                     dict_expected=dict_expected)

--- a/src/CIMS/model.py
+++ b/src/CIMS/model.py
@@ -166,6 +166,9 @@ class Model:
         if target_units is not None:
             print("  Configuring currency conversion...")
             self._configure_currency_conversion(target_units, deflator_path, exchange_path)
+            self.validator.currency_converter = self.currency_converter
+            self.validator.target_currency = self.target_currency
+            self.validator.target_dollar_year = self.target_dollar_year
 
         # Track current state of the model build
         self.status = "instantiated"  # description loaded, graph not yet constructed
@@ -232,6 +235,9 @@ class Model:
         return model
 
     def _configure_currency_conversion(self, target_units: dict, deflator_path: str, exchange_path: str):
+        if deflator_path is None or exchange_path is None:
+            missing = [name for name, val in [("deflator_path", deflator_path), ("exchange_path", exchange_path)] if val is None]
+            raise ValueError(f"{' and '.join(missing)} must be provided when target_units is set")
         self.target_currency = target_units["currency"]
         self.target_dollar_year = target_units["dollar_year"]
         self.currency_converter = CurrencyConverter(deflator_path, exchange_path)

--- a/src/CIMS/model_validation/file_errors.py
+++ b/src/CIMS/model_validation/file_errors.py
@@ -487,3 +487,48 @@ def no_structural_parent_node_exists(validator):
     total_children = sum(len(c) for c in missing_parents.values())
     concern_desc = f"parent node(s) are not defined — {total_children} child node(s) affected"
     return missing_parents, concern_desc
+
+
+def currency_table_coverage(validator):
+    """
+    Check that the deflator and exchange tables cover every monetary (year, currency)
+    pair present in the model data, as well as the configured target year/currency.
+
+    Skipped when no currency converter is configured on the validator.
+    """
+    converter = getattr(validator, "currency_converter", None)
+    if converter is None:
+        return [], ""
+
+    from ..unit_conversion import _MONETARY_PREFIX_RE
+
+    target_currency = validator.target_currency
+    target_year = validator.target_dollar_year
+
+    unit_col = validator.model_df[COL.unit].fillna("").astype(str)
+    extracted = unit_col.str.extract(_MONETARY_PREFIX_RE)
+    monetary_mask = extracted[0].notna()
+
+    if not monetary_mask.any():
+        return [], ""
+
+    source_pairs = set()
+    for year_str, currency_str in zip(extracted.loc[monetary_mask, 0], extracted.loc[monetary_mask, 1]):
+        try:
+            source_pairs.add((currency_str.upper(), int(year_str)))
+        except (ValueError, AttributeError):
+            pass
+
+    problems = []
+    seen = set()
+    for (source_currency, source_year) in sorted(source_pairs):
+        try:
+            converter.conversion_factor(source_currency, source_year, target_currency, target_year)
+        except ValueError as exc:
+            msg = str(exc)
+            if msg not in seen:
+                seen.add(msg)
+                problems.append(f"{source_currency} {source_year} → {target_currency} {target_year}: {exc}")
+
+    concern_desc = "currency table coverage gaps — year or currency missing from deflator/exchange tables"
+    return problems, concern_desc

--- a/src/CIMS/model_validation/file_warnings.py
+++ b/src/CIMS/model_validation/file_warnings.py
@@ -3,6 +3,7 @@ import numpy as np
 
 from ..utils.model_description import column_list as COL
 from ..utils.parameter import list as PARAM
+from ..unit_conversion import _MONETARY_PREFIX_RE
 
 
 def missing_parameter_default(validator):
@@ -134,6 +135,32 @@ def bad_service_req(validator):
         0's or are missing all values"
 
     return bad_service_requests, concern_desc
+
+
+def cost_params_missing_currency_unit(validator):
+    """
+    Identify rows whose Unit column looks monetary (contains '$') but is missing
+    a valid YYYY_CCC dollar-year prefix (e.g. '$/GJ' should be '2010_CAD/GJ').
+
+    Without the year prefix, configure_unit_conversion() silently skips those rows
+    and their values are not normalised to the target currency and dollar-year.
+    """
+    data = validator.model_df
+
+    dollar_mask = data[COL.unit].fillna('').str.contains(r'\$', regex=True)
+    monetary_prefix_mask = data[COL.unit].fillna('').str.match(_MONETARY_PREFIX_RE)
+
+    missing = data[dollar_mask & ~monetary_prefix_mask]
+
+    result = list(zip(
+        missing.index,
+        missing[validator.node_col],
+        missing[COL.parameter],
+        missing[COL.unit],
+    ))
+
+    concern_desc = "rows have a '$' unit missing a YYYY_CCC monetary prefix (e.g. '$/GJ' → '2010_CAD/GJ')"
+    return result, concern_desc
 
 
 def zero_requested_nodes(validator, providers):

--- a/src/CIMS/model_validation/file_warnings.py
+++ b/src/CIMS/model_validation/file_warnings.py
@@ -144,13 +144,21 @@ def cost_params_missing_currency_unit(validator):
 
     Without the year prefix, configure_unit_conversion() silently skips those rows
     and their values are not normalised to the target currency and dollar-year.
+
+    A secondary check flags rows whose parameter is in MONETARY_PARAMS but whose
+    unit does not match the YYYY_CCC pattern at all (e.g. 'fcc' with unit 'CAD'
+    rather than '2010_CAD'). This catches monetary parameters that lack a '$' symbol
+    and would otherwise be missed by the heuristic above.
     """
     data = validator.model_df
 
-    dollar_mask = data[COL.unit].fillna('').str.contains(r'\$', regex=True)
     monetary_prefix_mask = data[COL.unit].fillna('').str.match(_MONETARY_PREFIX_RE)
 
-    missing = data[dollar_mask & ~monetary_prefix_mask]
+    dollar_mask = data[COL.unit].fillna('').str.contains(r'\$', regex=True)
+    has_unit_mask = data[COL.unit].notna() & (data[COL.unit] != '')
+    monetary_param_mask = data[COL.parameter].isin(PARAM.MONETARY_PARAMS) & has_unit_mask
+
+    missing = data[(dollar_mask | monetary_param_mask) & ~monetary_prefix_mask]
 
     result = list(zip(
         missing.index,
@@ -159,7 +167,7 @@ def cost_params_missing_currency_unit(validator):
         missing[COL.unit],
     ))
 
-    concern_desc = "rows have a '$' unit missing a YYYY_CCC monetary prefix (e.g. '$/GJ' → '2010_CAD/GJ')"
+    concern_desc = "rows with a monetary parameter or '$' unit are missing a YYYY_CCC prefix (e.g. '$/GJ' → '2010_CAD/GJ')"
     return result, concern_desc
 
 

--- a/src/CIMS/model_validation/registry.py
+++ b/src/CIMS/model_validation/registry.py
@@ -514,6 +514,22 @@ REGISTRY.register("zero_requested_nodes", CheckSpec(
         "intentionally 0 or whether they should be non-zero."
     ),
 ))
+REGISTRY.register("cost_params_missing_currency_unit", CheckSpec(
+    fn=file_warnings.cost_params_missing_currency_unit,
+    phase=Phase.FILE,
+    severity=Severity.WARNING,
+    argmap={},
+    short_desc="rows with a '$' unit are missing a YYYY_CCC monetary year prefix",
+    help_text=(
+        "Output: [(row_index, node, parameter, unit)]\n"
+        "  Each entry is a row whose Unit contains '$' but lacks a YYYY_CCC prefix;\n"
+        "  row_index is that row in model_df.\n\n"
+        "Reading: configure_unit_conversion() uses the year prefix to identify which\n"
+        "rows to convert. Without it those values are silently skipped. Update the\n"
+        "Unit column to include the dollar-year and currency code\n"
+        "(e.g. '$/GJ' → '2010_CAD/GJ', '$' → '2010_CAD')."
+    ),
+))
 
 # ---------------------------------------------------------------------------
 # GRAPH-PHASE CHECKS (to be added)

--- a/src/CIMS/model_validation/registry.py
+++ b/src/CIMS/model_validation/registry.py
@@ -400,6 +400,22 @@ REGISTRY.register("nodes_missing_competition", CheckSpec(
     ),
 ))
 
+REGISTRY.register("currency_table_coverage", CheckSpec(
+    fn=file_errors.currency_table_coverage,
+    phase=Phase.FILE,
+    severity=Severity.ERROR,
+    argmap={},
+    short_desc="monetary units in the data cannot be converted — year or currency missing from deflator/exchange tables",
+    help_text=(
+        "Output: [\"SRC_CURRENCY SRC_YEAR → TARGET_CURRENCY TARGET_YEAR: <reason>\"]\n"
+        "  Each entry is a unique conversion that failed; reason is the missing key\n"
+        "  (e.g. 'Year 1800 not found in deflator table for CAD').\n\n"
+        "Reading: open the deflator CSV and confirm the target dollar-year row exists\n"
+        "for every currency present in the data. Open the exchange CSV and confirm the\n"
+        "required cross-currency rate exists for the target year. This check is skipped\n"
+        "when no target_units are configured."
+    ),
+))
 REGISTRY.register("no_structural_parent_node_exists", CheckSpec(
     fn=file_errors.no_structural_parent_node_exists,
     phase=Phase.FILE,

--- a/src/CIMS/unit_conversion.py
+++ b/src/CIMS/unit_conversion.py
@@ -1,0 +1,214 @@
+"""
+Unit conversion utilities for normalizing parameter values to a common currency and dollar-year
+at model read-time. Designed for future extension to physical unit conversion (e.g. energy units).
+"""
+import re
+import pandas as pd
+from pathlib import Path
+
+# Matches: 4-digit year, optional separator (_, space, or none), 3-letter currency code,
+# optional physical unit after / or _ (e.g. '2010_CAD', '2010_USD/GJ', '2010 CAD')
+_MONETARY_PREFIX_RE = re.compile(r'^(\d{4})\s*_?\s*([A-Za-z]{3})(?:[/_](.+))?$')
+
+
+def parse_unit_string(unit: str | None) -> tuple[int | None, str | None, str | None]:
+    """
+    Parse a unit string into its monetary prefix and physical unit components.
+
+    Accepts the canonical format (e.g. '2010_CAD', '2010_USD/GJ') and common
+    variations (e.g. '2010 CAD', '2010CAD').
+
+    Parameters
+    ----------
+    unit : str | None
+        Unit string from the model description.
+
+    Returns
+    -------
+    tuple[int | None, str | None, str | None]
+        (dollar_year, currency, physical_unit). dollar_year and currency are None
+        if no monetary prefix is present.
+    """
+    if not unit:
+        return None, None, unit
+
+    match = _MONETARY_PREFIX_RE.match(unit.strip())
+    if match:
+        return int(match.group(1)), match.group(2).upper(), match.group(3)
+
+    return None, None, unit
+
+
+class CurrencyConverter:
+    """Converts values between currencies and dollar-years using CPI and exchange rate tables."""
+
+    def __init__(self, deflator_path: str | Path, exchange_path: str | Path):
+        self._deflator = _load_table(deflator_path, key_col='Context')
+        self._exchange = _load_table(exchange_path, key_col='Context')
+
+    def conversion_factor(self, source_currency: str, source_year: int,
+                          target_currency: str, target_year: int) -> float:
+        """
+        Compute the factor to convert a value from source_currency/source_year
+        to target_currency/target_year.
+
+        Applies inflation in the source currency first, then exchanges to the target currency.
+
+        Parameters
+        ----------
+        source_currency : str
+            ISO currency code of the input value (e.g. 'USD').
+        source_year : int
+            Dollar-year of the input value.
+        target_currency : str
+            ISO currency code to convert to.
+        target_year : int
+            Dollar-year to convert to.
+
+        Returns
+        -------
+        float
+            Multiplicative conversion factor.
+        """
+        if source_currency == target_currency and source_year == target_year:
+            return 1.0
+        return (_inflate_factor(self._deflator, source_currency, source_year, target_year) *
+                _exchange_factor(self._exchange, source_currency, target_currency, target_year))
+
+    def convert(self, value: float, source_currency: str | None, source_year: int | None,
+                target_currency: str, target_year: int) -> float:
+        """Apply currency conversion to a value. Returns value unchanged if source_currency is None."""
+        if source_currency is None:
+            return value
+        return value * self.conversion_factor(source_currency, source_year, target_currency, target_year)
+
+
+def normalize_currency_in_df(
+    df: pd.DataFrame,
+    converter: CurrencyConverter,
+    target_currency: str,
+    target_dollar_year: int,
+) -> pd.DataFrame:
+    """
+    Apply currency/dollar-year conversion to monetary values in a DataFrame.
+
+    Rows whose Unit column has no monetary prefix are passed through unchanged.
+    Rows with a monetary prefix have their Value converted and their Unit updated
+    to reflect the target currency and dollar-year (e.g. '2010_USD/GJ' → '2020_CAD/GJ').
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Model description DataFrame with 'Unit' and 'Value' columns.
+    converter : CurrencyConverter
+    target_currency : str
+    target_dollar_year : int
+
+    Returns
+    -------
+    pd.DataFrame
+        A copy of df with converted values and updated unit strings.
+    """
+    df = df.copy()
+
+    if df.empty:
+        return df
+
+    extracted = df['Unit'].fillna('').astype(str).str.extract(_MONETARY_PREFIX_RE)
+    extracted.columns = ['dollar_year', 'currency', 'physical_unit']
+    monetary_mask = extracted['dollar_year'].notna()
+
+    if not monetary_mask.any():
+        return df
+
+    numeric_values = pd.to_numeric(df['Value'], errors='coerce')
+    # Only rows that are both monetary-prefixed AND have a convertible Value are
+    # actually converted. A row whose Value can't be converted must not have its
+    # Unit rewritten either — otherwise the label would claim a conversion that
+    # never happened.
+    convertible_mask = monetary_mask & numeric_values.notna()
+
+    extracted['currency'] = extracted['currency'].str.upper()
+    extracted['dollar_year'] = extracted['dollar_year'].astype('Int64')
+
+    for (currency, year), group in extracted[convertible_mask].groupby(['currency', 'dollar_year']):
+        factor = converter.conversion_factor(str(currency), int(year), target_currency, target_dollar_year)
+        df.loc[group.index, 'Value'] = numeric_values.loc[group.index] * factor
+
+    new_prefix = f"{target_dollar_year}_{target_currency}"
+    new_units = extracted.loc[convertible_mask, 'physical_unit'].apply(
+        lambda pu: f"{new_prefix}/{pu}" if pd.notna(pu) and pu else new_prefix
+    )
+    df.loc[convertible_mask, 'Unit'] = new_units
+
+    return df
+
+
+def apply_currency_conversion(
+    node_dfs: dict,
+    tech_dfs: dict,
+    converter: CurrencyConverter,
+    target_currency: str,
+    target_dollar_year: int,
+) -> tuple[dict, dict]:
+    """
+    Apply currency/dollar-year conversion to all node and technology DataFrames.
+
+    Parameters
+    ----------
+    node_dfs : dict[str, pd.DataFrame]
+    tech_dfs : dict[str, dict[str, pd.DataFrame]]
+    converter : CurrencyConverter
+    target_currency : str
+    target_dollar_year : int
+
+    Returns
+    -------
+    tuple[dict, dict]
+        Converted (node_dfs, tech_dfs).
+    """
+    converted_node_dfs = {
+        node: normalize_currency_in_df(df, converter, target_currency, target_dollar_year)
+        for node, df in node_dfs.items()
+    }
+    converted_tech_dfs = {
+        node: {
+            tech: normalize_currency_in_df(df, converter, target_currency, target_dollar_year)
+            for tech, df in tech_dict.items()
+        }
+        for node, tech_dict in tech_dfs.items()
+    }
+    return converted_node_dfs, converted_tech_dfs
+
+
+def _load_table(path: str | Path, key_col: str) -> dict[tuple[str, int], float]:
+    df = pd.read_csv(path)
+    return {(row[key_col], int(row['Year'])): float(row['Value']) for _, row in df.iterrows()}
+
+
+def _inflate_factor(deflator: dict, currency: str, source_year: int, target_year: int) -> float:
+    if source_year == target_year:
+        return 1.0
+    source_key = (currency, source_year)
+    target_key = (currency, target_year)
+    _check_deflator_key(deflator, source_key, currency, source_year)
+    _check_deflator_key(deflator, target_key, currency, target_year)
+    return deflator[target_key] / deflator[source_key]
+
+
+def _exchange_factor(exchange: dict, source_currency: str, target_currency: str, year: int) -> float:
+    if source_currency == target_currency:
+        return 1.0
+    key = (f"{target_currency}_per_{source_currency}", year)
+    if key not in exchange:
+        if year not in {k[1] for k in exchange}:
+            raise ValueError(f"Year {year} not found in exchange rate table.")
+        raise ValueError(f"{target_currency}_per_{source_currency} not found in exchange rate table.")
+    return exchange[key]
+
+
+def _check_deflator_key(table: dict, key: tuple, currency: str, year: int) -> None:
+    if key not in table:
+        if year not in {k[1] for k in table}:
+            raise ValueError(f"Year {year} not found in deflator table.")
+        raise ValueError(f"Currency {currency} not found in deflator table.")

--- a/src/CIMS/unit_conversion.py
+++ b/src/CIMS/unit_conversion.py
@@ -202,13 +202,25 @@ def _exchange_factor(exchange: dict, source_currency: str, target_currency: str,
     key = (f"{target_currency}_per_{source_currency}", year)
     if key not in exchange:
         if year not in {k[1] for k in exchange}:
-            raise ValueError(f"Year {year} not found in exchange rate table.")
-        raise ValueError(f"{target_currency}_per_{source_currency} not found in exchange rate table.")
+            raise ValueError(
+                f"Year {year} not found in exchange rate table. "
+                "Please review the exchange rate table for missing or out-of-range years."
+            )
+        raise ValueError(
+            f"{target_currency}_per_{source_currency} not found in exchange rate table. "
+            "Please review the exchange rate table for missing currencies."
+        )
     return exchange[key]
 
 
 def _check_deflator_key(table: dict, key: tuple, currency: str, year: int) -> None:
     if key not in table:
         if year not in {k[1] for k in table}:
-            raise ValueError(f"Year {year} not found in deflator table.")
-        raise ValueError(f"Currency {currency} not found in deflator table.")
+            raise ValueError(
+                f"Year {year} not found in deflator table. "
+                "Please review the deflator table for missing or out-of-range years."
+            )
+        raise ValueError(
+            f"Currency {currency} not found in deflator table. "
+            "Please review the deflator table for missing currencies."
+        )

--- a/src/CIMS/utils/parameter/list.py
+++ b/src/CIMS/utils/parameter/list.py
@@ -167,3 +167,55 @@ dic_min = "dic_min"
 dic_x50 = "dic_x50"
 multiplier_load_factor = "multiplier_load_factor"
 
+# ==========================================
+# Monetary Parameters
+# Parameters whose values are monetary and should carry a YYYY_CCC unit prefix
+# (e.g. "2010_CAD" or "2010_USD/GJ") whenever present in a model CSV.
+# ==========================================
+MONETARY_PARAMS = frozenset({
+    # Lifecycle Cost
+    capital_cost,
+    capital_cost_declining,
+    capital_cost_min,
+    competition_cost_annual,
+    competition_cost_upfront,
+    cost_curve_lcc_max,
+    cost_curve_lcc_min,
+    cost_curve_price,
+    emissions_cost,
+    fcc,
+    financial_cost_annual,
+    financial_cost_emissions,
+    financial_cost_service,
+    financial_cost_upfront,
+    fixed_cost_rate,
+    fixed_cost_total,
+    fom,
+    lcc_competition,
+    lcc_financial,
+    non_energy_cost,
+    non_energy_cost_change,
+    p2000,
+    price,
+    price_subsidy,
+    revenue_recycled,
+    service_cost,
+    stock_new_financial_cost_annual,
+    stock_new_financial_cost_upfront,
+    subsidy,
+    tax,
+    # Stock Allocation
+    export_subsidy,
+    fic,
+    global_price,
+    # Emissions
+    emissions_rate_cumul_cost,
+    emissions_rate_direct_cost,
+    emissions_total_cumul_cost,
+    emissions_total_direct_cost,
+    # Declining Costs
+    dic,
+    dic_initial,
+    dic_min,
+})
+

--- a/src/CIMS/utils/parameter/query.py
+++ b/src/CIMS/utils/parameter/query.py
@@ -4,6 +4,16 @@ from CIMS import declining_costs, lcc_calculation
 from ..graph.query import parent_name
 from . import list as PARAM
 
+def _return_val(val, param_source, unit, return_source, return_unit):
+    if return_source and return_unit:
+        return val, param_source, unit
+    if return_source:
+        return val, param_source
+    if return_unit:
+        return val, unit
+    return val
+
+
 calculation_directory = {
     PARAM.capital_cost_declining: declining_costs.calc_declining_capital_cost,
     PARAM.capital_cost: lcc_calculation.calc_capital_cost,
@@ -25,8 +35,8 @@ calculation_directory = {
 }
 
 def get_param(model, param, node, year=None, tech=None, context=None, sub_context=None,
-              target=None, return_source=False, do_calc=False, check_exist=False,
-              dict_expected=False):
+              target=None, return_source=False, return_unit=False, do_calc=False,
+              check_exist=False, dict_expected=False):
     """
     Gets a parameter's value from the model, given a specific context (node, year, tech, context, sub-context),
     calculating the parameter's value if needed.
@@ -118,8 +128,10 @@ def get_param(model, param, node, year=None, tech=None, context=None, sub_contex
                 val = val[None]
 
     # Grab the year_value in the dictionary if exists
+    unit = None
     if isinstance(val, dict) and (PARAM.year_value in val):
         param_source = val[PARAM.param_source]
+        unit = val.get(PARAM.unit)
         is_exogenous = param_source in ['model', 'initialization']
         val = val[PARAM.year_value]
 
@@ -137,16 +149,8 @@ def get_param(model, param, node, year=None, tech=None, context=None, sub_contex
 
         warnings.warn(warning_message)
 
-    if val is not None:
-        if not do_calc:
-            if return_source:
-                return val, param_source
-            return val
-        elif is_exogenous:
-            if return_source:
-                return val, param_source
-            else:
-                return val
+    if val is not None and (not do_calc or is_exogenous):
+        return _return_val(val, param_source, unit, return_source, return_unit)
 
     # If check_exist is True, raise an Exception if val has not yet been returned, which means
     # the value at the current context could not be found as is.
@@ -224,10 +228,7 @@ def get_param(model, param, node, year=None, tech=None, context=None, sub_contex
             val = None
             param_source = None
 
-    if return_source:
-        return val, param_source
-    else:
-        return val
+    return _return_val(val, param_source, unit, return_source, return_unit)
 
 def is_param_exogenous(model, param, node, year, tech=None):
     """Checks if a parameter is exogenously defined"""

--- a/src/CIMS/utils/parameter/query.py
+++ b/src/CIMS/utils/parameter/query.py
@@ -93,6 +93,7 @@ def get_param(model, param, node, year=None, tech=None, context=None, sub_contex
         default, or previous_year}.
     """
     val = None
+    param_source = None
     is_exogenous = None
 
     # Get Parameter from Description


### PR DESCRIPTION
## Closes #399 — Currency/dollar-year normalization for cost inputs

CIMS input data contains monetary parameters (fcc, fom, prices, etc.) expressed in different dollar-years and currencies depending on source. This PR adds the ability to normalize all cost inputs to a common currency and dollar-year at model load time, so that cost comparisons across sectors and technologies are on a consistent basis.

### What's new

**`unit_conversion.py` (new module)**
- `CurrencyConverter`: loads a CPI deflator table and an exchange rate table from CSV, and converts any monetary value between currencies and dollar-years
- `apply_currency_conversion`: walks the model's node/tech DataFrames, identifies rows with a `YYYY_CCC` unit prefix, and applies the appropriate inflation + exchange factors

**`Model` API**
- Three new optional parameters on `Model.__init__`: `target_units`, `deflator_path`, `exchange_path`. When provided, all monetary cost inputs are converted to the target currency and dollar-year before the graph is built.

**Validator checks**
- New `cost_params_missing_currency_unit` warning: flags any rows whose unit contains `$` but is missing a `YYYY_CCC` prefix — these would be silently skipped by conversion
- New `currency_table_coverage` error: scans all monetary unit strings and verifies the deflator and exchange tables cover every (source currency, source year) → target pair — catches misconfiguration at `validate_files()` before the graph is built

**Scenario notebooks**
- `Reference.py` and `Net Zero.py`: commented-out `target_units`/`deflator_path`/`exchange_path` args added to `Model()` with a note on what to provide once the currency CSVs are in place

### To activate
Add `currency_deflator.csv` and `currency_exchange.csv` to `data/model_inputs/` and uncomment the three args in the notebook `Model()` call. Unit strings in input CSVs must follow the `YYYY_CCC` format (e.g. `2010_CAD`).
