### PR TITLE
571 centralize filtering

### DIFF
--- a/scenarios/Net Zero.py
+++ b/scenarios/Net Zero.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.23.1"
+__generated_with = "0.21.1"
 app = marimo.App(width="medium")
 
 with app.setup:
@@ -67,11 +67,6 @@ def _():
         'agriculture',
         'forestry',
         ]
-    if sector_req:
-        if model_path not in update_files:
-            update_files[model_path] = []
-        update_files[model_path].extend(sector_req)
-
 
     ### Required model files (included in data/model_inputs/model/)
     model_req = [
@@ -80,10 +75,15 @@ def _():
         'FIC', # fixed intangible cost; primarily used for calibration
         'market share limits', # use of limits should be minimised
         ]
-    if model_req:
-        if model_path not in update_files:
-            update_files[model_path] = []
-        update_files[model_path].extend(model_req)
+
+    # Each entry below is (folder, [file/subfolder names]); merging just means
+    # appending the list onto update_files[folder], creating it if needed.
+    for _path, _files in [
+        (model_path, sector_req),
+        (model_path, model_req),
+    ]:
+        if _files:
+            update_files.setdefault(_path, []).extend(_files)
     return base_model, default_path, list_path, model_path, update_files
 
 
@@ -95,8 +95,16 @@ def _():
     return
 
 
+@app.cell(hide_code=True)
+def _():
+    mo.md(r"""
+    ### Region, year, and sector selection
+    """)
+    return
+
+
 @app.cell
-def _(model_path, update_files):
+def _():
     # Only uncommented regions below will be run in the simulation
     region_list = [
         'CIMS',
@@ -156,139 +164,155 @@ def _(model_path, update_files):
         'Agriculture',
         'Forestry',
     ]
+    return region_list, sector_list, year_list
 
 
+@app.cell(hide_code=True)
+def _():
+    mo.md(r"""
+    ### Update file specifications
+    """)
+    return
+
+
+@app.cell
+def _(model_path, update_files):
     ### Optional model folder files (included in data/model_inputs/model/)
     model_optional = [
         'exogenous prices',  # needed for correct calibration of historical years
         'exogenous demand',  # use this file when calibrating endogenous supply sectors
         ]
-    if model_optional:
-        if model_path not in update_files:
-            update_files[model_path] = []
-        update_files[model_path].extend(model_optional)
 
 
     ### Reference scenario update files (these files should always be included as the base model specification, but they can be excluded if appropriate for your scenario)
-    ref_path = 'data/model_inputs/policies/reference'
+    ref_path = 'data/new_model_inputs/policies/reference'
     ref_policies = [
-    ### Economy
+        ### Economy
         'Ref_carbon tax',
         'Ref_OBPS_Fed',
-    ### Coal Mining
-    ### Natural Gas Production
-    ### Petroleum Crude
-    ### Mining
-    ### Electricity
+        ### Coal Mining
+        ### Natural Gas Production
+        ### Petroleum Crude
+        ### Mining
+        ### Electricity
         'Ref_coal phase out',
         'Ref_nuclear ban',
         'Ref_nuclear decommission',
         'Ref_clean electricity',
         'Ref_CER',
-    ### Biodiesel
-    ### Ethanol
-    ### Hydrogen
-    ### Petroleum Refining
-    ### Industrial Minerals
-    ### Iron and Steel
-    ### Metal Smelting
-    ### Chemical Products
-    ### Pulp and Paper
-    ### Light Industrial
-    ### Residential
+        ### Biodiesel
+        ### Ethanol
+        ### Hydrogen
+        ### Petroleum Refining
+        ### Industrial Minerals
+        ### Iron and Steel
+        ### Metal Smelting
+        ### Chemical Products
+        ### Pulp and Paper
+        ### Light Industrial
+        ### Residential
         'Ref_incandescent phase out',
-    ### Commercial
-    ### Transportation Personal
+        ### Commercial
+        ### Transportation Personal
         'Ref_LDV ZEV_Federal', #include before Prov version
         'Ref_LDV ZEV_Prov',
         'Ref_renewable fuel content_Fed', #include before Prov version
         'Ref_renewable fuel content_Prov',
-    ### Transportation Freight
-    ### Waste
+        ### Transportation Freight
+        ### Waste
         'Ref_waste methane large sites',
-    ### Agriculture
+        ### Agriculture
         ]
-    if ref_policies:
-        if ref_path not in update_files:
-            update_files[ref_path] = []
-        update_files[ref_path].extend(ref_policies)
 
 
     # These files turn off existing Reference policies starting in the first model year
     # Off files must be updated annually to reflect the last common year between a set of scenarios
-    turn_off_path = 'data/model_inputs/policies/turn off'                                           
+    turn_off_path = 'data/new_model_inputs/policies/turn off'
     turn_off_policies = [
-    ### Economy
+        ### Economy
         'Off_OBPS_Fed',
-    ### Coal Mining
-    ### Natural Gas Production
-    ### Petroleum Crude
-    ### Mining
-    ### Electricity
-    ### Biodiesel
-    ### Ethanol
-    ### Hydrogen
-    ### Petroleum Refining
-    ### Industrial Minerals
-    ### Iron and Steel
-    ### Metal Smelting
-    ### Chemical Products
-    ### Pulp and Paper
-    ### Light Industrial
-    ### Residential
-    ### Commercial
-    ### Transportation Personal
-    ### Transportation Freight
-    ### Waste
-    ### Agriculture
+        ### Coal Mining
+        ### Natural Gas Production
+        ### Petroleum Crude
+        ### Mining
+        ### Electricity
+        ### Biodiesel
+        ### Ethanol
+        ### Hydrogen
+        ### Petroleum Refining
+        ### Industrial Minerals
+        ### Iron and Steel
+        ### Metal Smelting
+        ### Chemical Products
+        ### Pulp and Paper
+        ### Light Industrial
+        ### Residential
+        ### Commercial
+        ### Transportation Personal
+        ### Transportation Freight
+        ### Waste
+        ### Agriculture
         ]
-    if turn_off_policies:
-        if turn_off_path not in update_files:
-            update_files[turn_off_path] = []
-        update_files[turn_off_path].extend(turn_off_policies)
 
 
     ### Optional scenario update files
-    scenario_path = 'data/model_inputs/policies/net zero'    # Change this path as necessary based on current scenario
+    scenario_path = 'data/new_model_inputs/policies/net zero'    # Change this path as necessary based on current scenario
     scenario_policies = [
-    ### Economy
+        ### Economy
         'NZ_carbon tax',
-    ### Coal Mining
-    ### Natural Gas Production
+        ### Coal Mining
+        ### Natural Gas Production
         'NZ_natural gas production',
-    ### Petroleum Crude
+        ### Petroleum Crude
         'NZ_petroleum crude',
-    ### Mining
-    ### Electricity
+        ### Mining
+        ### Electricity
         'NZ_electricity generation',
-    ### Biodiesel
-    ### Ethanol
-    ### Hydrogen
-    ### Petroleum Refining
-    ### Industrial Minerals
-    ### Iron and Steel
-    ### Metal Smelting
-    ### Chemical Products
-    ### Pulp and Paper
-    ### Light Industrial
-    ### Residential
-    ### Commercial
-    ### Transportation Personal
-    ### Transportation Freight
-    ### Waste
-    ### Agriculture
+        ### Biodiesel
+        ### Ethanol
+        ### Hydrogen
+        ### Petroleum Refining
+        ### Industrial Minerals
+        ### Iron and Steel
+        ### Metal Smelting
+        ### Chemical Products
+        ### Pulp and Paper
+        ### Light Industrial
+        ### Residential
+        ### Commercial
+        ### Transportation Personal
+        ### Transportation Freight
+        ### Waste
+        ### Agriculture
         ]
-    if scenario_policies:
-        if scenario_path not in update_files:
-            update_files[scenario_path] = []
-        update_files[scenario_path].extend(scenario_policies)
+
+    # Each entry below is (folder, [file/subfolder names]); merging just means
+    # appending the list onto update_files[folder], creating it if needed.
+    for _path, _files in [
+        (model_path, model_optional),
+        (ref_path, ref_policies),
+        (turn_off_path, turn_off_policies),
+        (scenario_path, scenario_policies),
+    ]:
+        if _files:
+            update_files.setdefault(_path, []).extend(_files)
+    return
 
 
+@app.cell(hide_code=True)
+def _():
+    mo.md(r"""
+    ### Scenario name
+    """)
+    return
 
+
+@app.cell
+def _():
     ### Scenario Name
     ### This will be the save location for results (i.e., results_dir/scenario_name/results_general.csv)
     scenario_name = 'Net Zero'  # Set this to current scenario (e.g., "Reference", "Net Zero")
-    return region_list, scenario_name, sector_list, year_list
+    return (scenario_name,)
 
 
 @app.cell(hide_code=True)
@@ -310,10 +334,9 @@ def _(
     update_files,
     year_list,
 ):
-    #################### Instantiate Model ####################
     model = CIMS.Model(
         model_path=model_path,
-        base_model=base_model,
+        base_model= base_model,
         region_list=region_list,
         update_files=update_files,
         year_list=year_list,
@@ -374,10 +397,10 @@ def _(model, scenario_name):
 def _(model, results_path):
     #################### Output Results ###########################
     results_df = CIMS.log_model(
-       model=model, 
+       model=model,
        output_file = f"{results_path}/results_general.csv",
        parameter_file="results/results_general.txt",
-       ensure_dir=True   
+       ensure_dir=True
     )
     return
 
@@ -386,7 +409,7 @@ def _(model, results_path):
 def _(model, results_path):
     #################### Export Tech Results ####################
     tech_results_df = CIMS.log_model(
-       model=model, 
+       model=model,
        output_file=f'{results_path}/results_tech.csv',
        parameter_file = "results/results_tech.txt",
        ensure_dir=True

--- a/scenarios/Reference.py
+++ b/scenarios/Reference.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.23.1"
+__generated_with = "0.21.1"
 app = marimo.App(width="medium")
 
 with app.setup:
@@ -67,11 +67,6 @@ def _():
         'agriculture',
         'forestry',
         ]
-    if sector_req:
-        if model_path not in update_files:
-            update_files[model_path] = []
-        update_files[model_path].extend(sector_req)
-
 
     ### Required model files (included in data/model_inputs/model/)
     model_req = [
@@ -80,10 +75,15 @@ def _():
         'FIC', # fixed intangible cost; primarily used for calibration
         'market share limits', # use of limits should be minimised
         ]
-    if model_req:
-        if model_path not in update_files:
-            update_files[model_path] = []
-        update_files[model_path].extend(model_req)
+
+    # Each entry below is (folder, [file/subfolder names]); merging just means
+    # appending the list onto update_files[folder], creating it if needed.
+    for _path, _files in [
+        (model_path, sector_req),
+        (model_path, model_req),
+    ]:
+        if _files:
+            update_files.setdefault(_path, []).extend(_files)
     return base_model, default_path, list_path, model_path, update_files
 
 
@@ -95,8 +95,16 @@ def _():
     return
 
 
+@app.cell(hide_code=True)
+def _():
+    mo.md(r"""
+    ### Region, year, and sector selection
+    """)
+    return
+
+
 @app.cell
-def _(model_path, update_files):
+def _():
     # Only uncommented regions below will be run in the simulation
     region_list = [
         'CIMS', # Required
@@ -132,7 +140,7 @@ def _(model_path, update_files):
     # Uncomment individual sectors to calibrate one at a time
     # Must use Exogenous prices (and optional exogenous demand) file below when calibrating
     sector_list = [
-        'Coal Mining'
+        'Coal Mining',
         # 'Natural Gas', # Must run all regions due to Natural Gas Market
         # 'Petroleum Crude', # Must also run 'Natural Gas' sector since shared fuel blending
         'Petroleum Refining',
@@ -156,140 +164,156 @@ def _(model_path, update_files):
         'Agriculture',
         'Forestry',
     ]
+    return region_list, sector_list, year_list
 
 
+@app.cell(hide_code=True)
+def _():
+    mo.md(r"""
+    ### Update file specifications
+    """)
+    return
+
+
+@app.cell
+def _(model_path, update_files):
     ### Optional model folder files (included in data/model_inputs/model/)
     model_optional = [
         'exogenous prices',  # needed for correct calibration of historical years
         # 'exogenous demand',  # use this file when calibrating endogenous supply sectors
         ]
-    if model_optional:
-        if model_path not in update_files:
-            update_files[model_path] = []
-        update_files[model_path].extend(model_optional)
 
 
     ### Reference scenario update files (these files should always be included as the base model specification, but they can be excluded if appropriate for your scenario)
     ref_path = 'data/model_inputs/policies/reference'
     ref_policies = [
         # 'coal mining',   # <-- add this
-    ### Economy
+        ### Economy
         'Ref_carbon tax',
         'Ref_OBPS_Fed',
-    ### Coal Mining
-    ### Natural Gas Production
-    ### Petroleum Crude
-    ### Mining
-    ### Electricity
+        ### Coal Mining
+        ### Natural Gas Production
+        ### Petroleum Crude
+        ### Mining
+        ### Electricity
         'Ref_coal phase out',
         'Ref_nuclear ban',
         'Ref_nuclear decommission',
         'Ref_clean electricity',
         'Ref_CER',
-    ### Biodiesel
-    ### Ethanol
-    ### Hydrogen
-    ### Petroleum Refining
-    ### Industrial Minerals
-    ### Iron and Steel
-    ### Metal Smelting
-    ### Chemical Products
-    ### Pulp and Paper
-    ### Light Industrial
-    ### Residential
+        ### Biodiesel
+        ### Ethanol
+        ### Hydrogen
+        ### Petroleum Refining
+        ### Industrial Minerals
+        ### Iron and Steel
+        ### Metal Smelting
+        ### Chemical Products
+        ### Pulp and Paper
+        ### Light Industrial
+        ### Residential
         'Ref_incandescent phase out',
-    ### Commercial
-    ### Transportation Personal
+        ### Commercial
+        ### Transportation Personal
         'Ref_LDV ZEV_Federal', #include before Prov version
         'Ref_LDV ZEV_Prov',
         'Ref_renewable fuel content_Fed', #include before Prov version
         'Ref_renewable fuel content_Prov',
-    ### Transportation Freight
-    ### Waste
+        ### Transportation Freight
+        ### Waste
         'Ref_waste methane large sites',
-    ### Agriculture
+        ### Agriculture
         ]
-    if ref_policies:
-        if ref_path not in update_files:
-            update_files[ref_path] = []
-        update_files[ref_path].extend(ref_policies)
 
 
     # These files turn off existing Reference policies starting in the first model year
     # Off files must be updated annually to reflect the last common year between a set of scenarios
     turn_off_path = 'data/model_inputs/policies/turn off'
     turn_off_policies = [
-    ### Economy
+        ### Economy
         # 'Off_OBPS_Fed',
-    ### Coal Mining
-    ### Natural Gas Production
-    ### Petroleum Crude
-    ### Mining
-    ### Electricity
-    ### Biodiesel
-    ### Ethanol
-    ### Hydrogen
-    ### Petroleum Refining
-    ### Industrial Minerals
-    ### Iron and Steel
-    ### Metal Smelting
-    ### Chemical Products
-    ### Pulp and Paper
-    ### Light Industrial
-    ### Residential
-    ### Commercial
-    ### Transportation Personal
-    ### Transportation Freight
-    ### Waste
-    ### Agriculture
+        ### Coal Mining
+        ### Natural Gas Production
+        ### Petroleum Crude
+        ### Mining
+        ### Electricity
+        ### Biodiesel
+        ### Ethanol
+        ### Hydrogen
+        ### Petroleum Refining
+        ### Industrial Minerals
+        ### Iron and Steel
+        ### Metal Smelting
+        ### Chemical Products
+        ### Pulp and Paper
+        ### Light Industrial
+        ### Residential
+        ### Commercial
+        ### Transportation Personal
+        ### Transportation Freight
+        ### Waste
+        ### Agriculture
         ]
-    if turn_off_policies:
-        if turn_off_path not in update_files:
-            update_files[turn_off_path] = []
-        update_files[turn_off_path].extend(turn_off_policies)
 
 
     ### Optional scenario update files
     scenario_path = 'data/model_inputs/policies/net zero'    # Change this path as necessary based on current scenario
     scenario_policies = [
-    ### Economy
+        ### Economy
         # 'NZ_carbon tax',
-    ### Coal Mining
-    ### Natural Gas Production
+        ### Coal Mining
+        ### Natural Gas Production
         # 'NZ_natural gas',
-    ### Petroleum Crude
+        ### Petroleum Crude
         # 'NZ_petroleum crude',
-    ### Mining
-    ### Electricity
+        ### Mining
+        ### Electricity
         # 'NZ_electricity',
-    ### Biodiesel
-    ### Ethanol
-    ### Hydrogen
-    ### Petroleum Refining
-    ### Industrial Minerals
-    ### Iron and Steel
-    ### Metal Smelting
-    ### Chemical Products
-    ### Pulp and Paper
-    ### Light Industrial
-    ### Residential
-    ### Commercial
-    ### Transportation Personal
-    ### Transportation Freight
-    ### Waste
-    ### Agriculture
+        ### Biodiesel
+        ### Ethanol
+        ### Hydrogen
+        ### Petroleum Refining
+        ### Industrial Minerals
+        ### Iron and Steel
+        ### Metal Smelting
+        ### Chemical Products
+        ### Pulp and Paper
+        ### Light Industrial
+        ### Residential
+        ### Commercial
+        ### Transportation Personal
+        ### Transportation Freight
+        ### Waste
+        ### Agriculture
         ]
-    if scenario_policies:
-        if scenario_path not in update_files:
-            update_files[scenario_path] = []
-        update_files[scenario_path].extend(scenario_policies)
+
+    # Each entry below is (folder, [file/subfolder names]); merging just means
+    # appending the list onto update_files[folder], creating it if needed.
+    for _path, _files in [
+        (model_path, model_optional),
+        (ref_path, ref_policies),
+        (turn_off_path, turn_off_policies),
+        (scenario_path, scenario_policies),
+    ]:
+        if _files:
+            update_files.setdefault(_path, []).extend(_files)
+    return
 
 
+@app.cell(hide_code=True)
+def _():
+    mo.md(r"""
+    ### Scenario name
+    """)
+    return
 
+
+@app.cell
+def _():
     ### Scenario Name
     ### This will be the save location for results (i.e., results_dir/scenario_name/results_general.csv)
     scenario_name = 'Reference'  # Set this to current scenario (e.g., "Reference", "Net Zero")
-    return region_list, scenario_name, sector_list, year_list
+    return (scenario_name,)
 
 
 @app.cell(hide_code=True)
@@ -335,7 +359,8 @@ def _(model):
 def _(model):
     #################### Show validator warnings ####################
     # change warning type as needed to view indicated nodes/techs
-    model.validator.warnings['unrequested_nodes']
+    model.validator.warnings['undefined_nodes']
+    # list(model.validator.warnings['undefined_nodes'].keys())
     return
 
 
@@ -374,10 +399,10 @@ def _(model, scenario_name):
 def _(model, results_path):
     #################### Output Results ###########################
     results_df = CIMS.log_model(
-       model=model, 
+       model=model,
        output_file = f"{results_path}/results_general.csv",
        parameter_file="results/results_general.txt",
-       ensure_dir=True   
+       ensure_dir=True
     )
     return
 
@@ -386,7 +411,7 @@ def _(model, results_path):
 def _(model, results_path):
     #################### Export Tech Results ####################
     tech_results_df = CIMS.log_model(
-       model=model, 
+       model=model,
        output_file=f'{results_path}/results_tech.csv',
        parameter_file = "results/results_tech.txt",
        ensure_dir=True

--- a/src/CIMS/__init__.py
+++ b/src/CIMS/__init__.py
@@ -1,8 +1,6 @@
 from .model import Model
 from .quantities import ProvidedQuantity, RequestedQuantity
 from .model import load_model
-from .readers import ModelReader, ScenarioReader
-from .model_validation.ModelValidator import ModelValidator
 from .logging import log_model, search_parameter
 from .download import download_models
 

--- a/src/CIMS/model.py
+++ b/src/CIMS/model.py
@@ -12,7 +12,7 @@ from .utils.model_description import column_list as COL
 from .utils.parameter import construction, list as PARAM, setters, query as param_query
 from .utils.graph import node_utils, edge_utils, loop_resolution, traversals, query as graph_query 
 from .utils.model_description.columns_builder import build_col_list
-from .readers.helpers import collect_base_paths, collect_update_paths, collect_all_paths, filter_model_data
+from .readers.helpers import collect_base_files, collect_update_files, collect_files, filter_model_data, print_file_health
 
 from . import lcc_calculation
 from . import stock_allocation
@@ -81,16 +81,17 @@ class Model:
         self._col_list = col_list
 
         print("  Collecting Base & Update CSV paths...")
-        base_paths, update_paths = collect_all_paths(
+        base_paths, update_paths, self._file_health_rows = collect_files(
             model_path=model_path,
             base_model=base_model,
             region_list=region_list,
+            sector_list=sector_list,
             update_files=update_files,
         )
 
         print("  Reading & filtering model CSVs...")
-        base_df = filter_model_data(base_paths, sector_list, year_list, col_list)
-        update_df = filter_model_data(update_paths, sector_list, year_list, col_list)
+        base_df = filter_model_data(base_paths, region_list, sector_list, year_list, col_list)
+        update_df = filter_model_data(update_paths, region_list, sector_list, year_list, col_list)
 
         print("  Instantiating ModelValidator...")
         self.validator = ModelValidator(
@@ -160,8 +161,12 @@ class Model:
 
         print(f"=== Model instantiation complete (completed in {time.time() - start_init:.2f}s) ===")
 
-    def validate_files(self):            
+    def validate_files(self):
         self.validator.validate()
+
+    def print_file_health(self, verbose: bool = True):
+        """Reprint the file health report from instantiation; verbose=True for the full per-entry table."""
+        print_file_health(self._file_health_rows, verbose=verbose)
         
     def validate_graph(self):
         self.validator.validate_graph()
@@ -189,8 +194,10 @@ class Model:
                              already been run. To prevent inconsistencies, \
                              this update has not been done.")
 
-        update_paths, _, _ = collect_update_paths(update_files, self._region_list)
-        update_df = filter_model_data(update_paths, self._sector_list, self._year_list, self._col_list)
+        update_paths, _ = collect_update_files(update_files)
+        update_df = filter_model_data(
+            update_paths, self._region_list, self._sector_list, self._year_list, self._col_list
+        )
         scenario_reader = ModelReader(model_df=update_df)
 
         # Make a copy, so we don't alter self

--- a/src/CIMS/model.py
+++ b/src/CIMS/model.py
@@ -21,7 +21,6 @@ from . import cost_curves
 from . import aggregation
 from . import visualize
 
-from .readers.scenario_reader import ScenarioReader
 from .readers.model_reader import ModelReader
 from .model_validation import ModelValidator, ValidationError
 from .quantities import ProvidedQuantity
@@ -112,7 +111,7 @@ class Model:
             list_csv_path=list_csv_path,
         )
 
-        self._scenario_reader = ScenarioReader(model_df=update_df)
+        self._scenario_reader = ModelReader(model_df=update_df)
 
         print("  Initializing model metadata and defaults...")
         self.root = self._model_reader.root
@@ -192,7 +191,7 @@ class Model:
 
         _, update_paths = collect_update_paths(update_files, self._region_list)
         update_df = filter_model_data(update_paths, self._sector_list, self._year_list, self._col_list)
-        scenario_reader = ScenarioReader(model_df=update_df)
+        scenario_reader = ModelReader(model_df=update_df)
 
         # Make a copy, so we don't alter self
         model = copy.deepcopy(self)
@@ -260,11 +259,6 @@ class Model:
         print("  Base graph constructed")
 
         # --- Apply scenario overlays (if any) --------------------------------
-        if not isinstance(self._scenario_reader, ScenarioReader):
-            raise ValueError(
-                "You are attempting to update a model with something other than a ScenarioReader object."
-            )
-
         # Only do work if there is scenario content
         if self.scenario_node_dfs or self.scenario_tech_dfs:
             self.graph.max_tree_index[0] = 0

--- a/src/CIMS/model.py
+++ b/src/CIMS/model.py
@@ -189,7 +189,7 @@ class Model:
                              already been run. To prevent inconsistencies, \
                              this update has not been done.")
 
-        _, update_paths = collect_update_paths(update_files, self._region_list)
+        update_paths, _, _ = collect_update_paths(update_files, self._region_list)
         update_df = filter_model_data(update_paths, self._sector_list, self._year_list, self._col_list)
         scenario_reader = ModelReader(model_df=update_df)
 

--- a/src/CIMS/model.py
+++ b/src/CIMS/model.py
@@ -73,7 +73,7 @@ class Model:
         start_init = time.time()
 
         print("  Building column list...")
-        col_list = build_col_list(list_csv_path, year_list)
+        col_list = build_col_list(list_csv_path)
 
         print("  Collecting Base & Update CSV paths...")
         base_paths, update_paths = collect_all_paths(

--- a/src/CIMS/model.py
+++ b/src/CIMS/model.py
@@ -12,7 +12,7 @@ from .utils.model_description import column_list as COL
 from .utils.parameter import construction, list as PARAM, setters, query as param_query
 from .utils.graph import node_utils, edge_utils, loop_resolution, traversals, query as graph_query 
 from .utils.model_description.columns_builder import build_col_list
-from .readers.helpers import collect_base_paths, collect_update_paths, collect_all_paths
+from .readers.helpers import collect_base_paths, collect_update_paths, collect_all_paths, filter_model_data
 
 from . import lcc_calculation
 from . import stock_allocation
@@ -72,8 +72,14 @@ class Model:
         print("\n=== Instantiating Model ===")
         start_init = time.time()
 
+        # Stored so update() can rebuild scenario paths/filters identically to __init__
+        self._region_list = list(region_list)
+        self._sector_list = sector_list
+        self._year_list = list(year_list)
+
         print("  Building column list...")
         col_list = build_col_list(list_csv_path)
+        self._col_list = col_list
 
         print("  Collecting Base & Update CSV paths...")
         base_paths, update_paths = collect_all_paths(
@@ -82,13 +88,16 @@ class Model:
             region_list=region_list,
             update_files=update_files,
         )
+
+        print("  Reading & filtering model CSVs...")
+        base_df = filter_model_data(base_paths, sector_list, year_list, col_list)
+        update_df = filter_model_data(update_paths, sector_list, year_list, col_list)
+
         print("  Instantiating ModelValidator...")
         self.validator = ModelValidator(
-            csv_file_paths=base_paths,
-            csv_update_file_paths=update_paths,
-            col_list=col_list,
+            base_df=base_df,
+            scenario_df=update_df,
             year_list=year_list,
-            sector_list=sector_list,
             default_values_csv_path=default_values_csv_path,
             list_csv_path=list_csv_path,
         )
@@ -98,20 +107,12 @@ class Model:
 
         print("  Instantiating Readers...")
         self._model_reader = ModelReader(
-            csv_file_paths=base_paths,
-            col_list=col_list,
-            year_list=year_list,
-            sector_list=sector_list,
+            model_df=base_df,
             default_values_csv_path=default_values_csv_path,
             list_csv_path=list_csv_path,
         )
 
-        self._scenario_reader = ScenarioReader(
-            csv_file_paths=update_paths,
-            col_list=col_list,
-            year_list=year_list,
-            sector_list=sector_list,
-        )
+        self._scenario_reader = ScenarioReader(model_df=update_df)
 
         print("  Initializing model metadata and defaults...")
         self.root = self._model_reader.root
@@ -138,7 +139,7 @@ class Model:
 
         # Run / logging metadata
         self.show_run_warnings = True
-        self.model_description_file_prefix = os.path.commonprefix(self._model_reader.csv_files)
+        self.model_description_file_prefix = os.path.commonprefix(base_paths)
 
         self.change_history = pd.DataFrame(
             columns=[
@@ -156,7 +157,7 @@ class Model:
 
         # Track current state of the model build
         self.status = "instantiated"  # description loaded, graph not yet constructed
-        self.scenario_model_description_file = self._scenario_reader.csv_files
+        self.scenario_model_description_file = update_paths
 
         print(f"=== Model instantiation complete (completed in {time.time() - start_init:.2f}s) ===")
 
@@ -166,15 +167,18 @@ class Model:
     def validate_graph(self):
         self.validator.validate_graph()
     
-    def update(self, scenario_model_reader):
+    def update(self, update_files: Mapping[str, Iterable[str]]):
         """
-        Create an updated version of self based off another ModelReader.
+        Create an updated version of self using new scenario/update files.
         Intended for use with a reference + scenario model setup.
 
         Parameters
         ----------
-        scenario_model_reader : CIMS.ModelReader
-            An instantiated ModelReader to be used for updating self.
+        update_files : Mapping[str, Iterable[str]]
+            Same shape as the `update_files` argument to Model(...): a mapping
+            of directory to the file-name stems of the scenario CSVs to apply.
+            Collected and filtered using this model's own region/sector/year
+            configuration, exactly as Model.__init__ does for its own scenario files.
 
         Returns
         -------
@@ -186,15 +190,15 @@ class Model:
                              already been run. To prevent inconsistencies, \
                              this update has not been done.")
 
-        if not isinstance(scenario_model_reader, ScenarioReader):
-            raise ValueError("You are attempting to update a model with \
-                             something other than a ScenarioReader object.")
+        _, update_paths = collect_update_paths(update_files, self._region_list)
+        update_df = filter_model_data(update_paths, self._sector_list, self._year_list, self._col_list)
+        scenario_reader = ScenarioReader(model_df=update_df)
 
         # Make a copy, so we don't alter self
         model = copy.deepcopy(self)
 
         # Update the model's node_df & tech_dfs
-        model.scenario_node_dfs, model.scenario_tech_dfs = scenario_model_reader.get_model_description()
+        model.scenario_node_dfs, model.scenario_tech_dfs = scenario_reader.get_model_description()
 
         # Update the nodes & edges in the graph
         self.graph.max_tree_index[0] = 0    # For Excel results viewer TODO: remove once we switch to notebook visualization
@@ -214,7 +218,7 @@ class Model:
         model._initialize_tax()
 
         model.show_run_warnings = True
-        model.scenario_model_description_file = scenario_model_reader.csv_files
+        model.scenario_model_description_file = update_paths
 
         return model
 

--- a/src/CIMS/model_validation/ModelValidator.py
+++ b/src/CIMS/model_validation/ModelValidator.py
@@ -6,28 +6,25 @@ from typing import List
 import time 
 
 from .validation_utils import get_providers, get_requested
-from ..readers.helpers import filter_model_data
 from ..utils.model_description import column_list as COL
 
 from .registry import REGISTRY, resolve_kwargs, Phase, Severity
 
 
 class ModelValidator:
-    def __init__(self, csv_file_paths, col_list, year_list, sector_list,
-                 csv_update_file_paths=None, default_values_csv_path=None, node_col=COL.branch,
+    def __init__(self, base_df, scenario_df, year_list,
+                 default_values_csv_path=None, node_col=COL.branch,
                  target_col=COL.target, root_node="CIMS", list_csv_path=None):
 
-        self.csv_files = csv_file_paths
-        self.scenario_files = csv_update_file_paths or []
+        self._base_df = base_df.copy()
+        self._scenario_df = scenario_df.copy()
 
         self.default_param_df = self.get_default_df(default_values_csv_path)
         self.competition_types = self._get_list(list_csv_path, column_identifier="Competition")
 
         self.node_col = node_col
         self.target_col = target_col
-        self.col_list = col_list
         self.year_list = [str(x) for x in year_list]
-        self.sector_list = sector_list
 
         self.model_df = self._get_model_df()
         self.root_node = root_node
@@ -46,15 +43,13 @@ class ModelValidator:
         self.graph_validation_warnings = False
 
     def _get_model_df(self, read_base_file=True, read_scenario_files=True):
-        files_to_read = []
+        frames = []
         if read_base_file:
-            for file in self.csv_files:
-                files_to_read.append(file)
+            frames.append(self._base_df)
         if read_scenario_files:
-            for file in self.scenario_files:
-                files_to_read.append(file)
+            frames.append(self._scenario_df)
 
-        mdf = filter_model_data(files_to_read, self.sector_list, self.year_list, self.col_list)
+        mdf = pd.concat(frames, ignore_index=True) if frames else self._base_df.iloc[0:0].copy()
         mdf[COL.parameter] = mdf[COL.parameter].str.lower()
 
         return mdf

--- a/src/CIMS/model_validation/ModelValidator.py
+++ b/src/CIMS/model_validation/ModelValidator.py
@@ -6,6 +6,7 @@ from typing import List
 import time 
 
 from .validation_utils import get_providers, get_requested
+from ..readers.helpers import filter_model_data
 from ..utils.model_description import column_list as COL
 
 from .registry import REGISTRY, resolve_kwargs, Phase, Severity
@@ -53,31 +54,7 @@ class ModelValidator:
             for file in self.scenario_files:
                 files_to_read.append(file)
 
-        appended_data = []
-        for csv_file in files_to_read:
-            try:
-                sheet_df = pl.read_csv(
-                    csv_file,
-                    use_pyarrow=False,
-                    infer_schema_length=0,
-                ).to_pandas().replace({np.nan: None, "": None})
-                appended_data.append(sheet_df)
-
-            except ValueError:
-                print(f"Warning: Unable to parse csv_path at {csv_file}. Skipping.")
-
-        model_df = pd.concat(appended_data,
-                             ignore_index=True)  # Add province sheets together and re-index
-        
-        # Filter sectors (if applicable)
-        if self.sector_list:
-            if None not in self.sector_list:
-                self.sector_list.append(None)
-            model_df = model_df[model_df[COL.sector].isin(self.sector_list)]
-
-        meta_cols = [c for c in model_df.columns if c not in ("Year", "Value") and c in self.col_list]
-        year_mask = model_df["Year"].isin(self.year_list) | model_df["Year"].isna()
-        mdf = model_df[year_mask][meta_cols + ["Year", "Value"]]
+        mdf = filter_model_data(files_to_read, self.sector_list, self.year_list, self.col_list)
         mdf[COL.parameter] = mdf[COL.parameter].str.lower()
 
         return mdf

--- a/src/CIMS/model_validation/file_errors.py
+++ b/src/CIMS/model_validation/file_errors.py
@@ -327,7 +327,7 @@ def new_techs_in_scenario(validator):
     Identify new technologies included in the scenario models (i.e. were not in
     the base model) but which don't have a technology parameter.
     """
-    if validator.scenario_files:
+    if not validator._scenario_df.empty:
         # The model dataframes
         base_data = validator._get_model_df(read_scenario_files=False)
         scenario_data = validator._get_model_df(read_base_file=False)

--- a/src/CIMS/readers/__init__.py
+++ b/src/CIMS/readers/__init__.py
@@ -1,2 +1,1 @@
 from .model_reader import ModelReader
-from .scenario_reader import ScenarioReader

--- a/src/CIMS/readers/helpers.py
+++ b/src/CIMS/readers/helpers.py
@@ -3,6 +3,12 @@ from pathlib import Path
 from typing import Iterable, Mapping, List, Tuple
 from tabulate import tabulate
 
+import numpy as np
+import pandas as pd
+import polars as pl
+
+from ..utils.model_description import column_list as COL
+
 COL_NAME = "File Name"
 COL_LOADED_TOTAL = ""
 COL_LOADED = "Loaded"
@@ -122,3 +128,51 @@ def collect_all_paths(
 
     _print_combined_summary(base_rows + update_rows)
     return base_found, update_found
+
+
+def _scannable(path: str) -> bool:
+    """Check a CSV has the columns filter_model_data requires, without fully reading it."""
+    try:
+        cols = pl.scan_csv(path, infer_schema_length=0).collect_schema().names()
+        return COL.sector in cols and COL.year in cols and COL.value in cols
+    except Exception:
+        return False
+
+
+def filter_model_data(
+    paths: Iterable[str],
+    sector_list: Iterable,
+    year_list: Iterable,
+    col_list: Iterable[str],
+) -> pd.DataFrame:
+    """Read, concatenate, and filter model input CSVs by sector and year in one lazy pass.
+
+    Rows with a null Sector or null Year are always kept (constants / non-sector-specific
+    rows). An empty/falsy sector_list applies no sector filtering.
+    """
+    year_strs = [str(y) for y in year_list]
+    sectors = list(sector_list) if sector_list else None
+
+    lazy_frames = []
+    for path in paths:
+        if not _scannable(path):
+            print(f"Warning: Unable to parse csv_path at {path}. Skipping.")
+            continue
+        lf = pl.scan_csv(path, infer_schema_length=0)
+        if sectors:
+            lf = lf.filter(pl.col(COL.sector).is_in(sectors) | pl.col(COL.sector).is_null())
+        lf = lf.filter(pl.col(COL.year).is_in(year_strs) | pl.col(COL.year).is_null())
+        lazy_frames.append(lf)
+
+    if not lazy_frames:
+        return pd.DataFrame(columns=list(col_list) + [COL.year, COL.value])
+
+    df = (
+        pl.concat(lazy_frames, how="diagonal_relaxed")
+        .collect()
+        .to_pandas()
+        .replace({np.nan: None, "": None})
+    )
+
+    meta_cols = [c for c in df.columns if c not in (COL.year, COL.value) and c in col_list]
+    return df[meta_cols + [COL.year, COL.value]]

--- a/src/CIMS/readers/helpers.py
+++ b/src/CIMS/readers/helpers.py
@@ -1,4 +1,4 @@
-from collections import defaultdict, Counter
+from collections import Counter
 from pathlib import Path
 from typing import Iterable, Mapping, List, Tuple
 from tabulate import tabulate
@@ -10,34 +10,89 @@ import polars as pl
 from ..utils.model_description import column_list as COL
 
 COL_NAME = "File Name"
-COL_LOADED_TOTAL = ""
-COL_LOADED = "Loaded"
-COL_NOT_FOUND = "Not Found"
+COL_FOUND = "Files Found"
+COL_UNREADABLE = "Unreadable"
 
-def _build_rows(summary: dict, total_regions: int) -> List[dict]:
-    """Build rows for the summary table with alphabetized region lists."""
+
+def _glob_csvs(directory: Path) -> List[Path]:
+    """List every CSV file directly inside directory.
+
+    No naming convention is required — a file may contain rows for any mix of
+    regions/sectors, since filtering happens later on the row data itself
+    (see filter_model_data), not by which files are selected.
+    """
+    if not directory.exists():
+        return []
+    return sorted(directory.glob("*.csv"))
+
+
+def _scannable(path) -> bool:
+    """Check a CSV has the columns filter_model_data requires, without fully reading it."""
+    try:
+        cols = pl.scan_csv(path, infer_schema_length=0).collect_schema().names()
+        return COL.region in cols and COL.sector in cols and COL.year in cols and COL.value in cols
+    except Exception:
+        return False
+
+
+def _build_rows(summary: dict) -> List[dict]:
+    """Build rows for the per-entry file health table."""
     rows = []
     for name, info in summary.items():
-        loaded = sorted(info["loaded_regions"])
-        missing = sorted(info["missing_regions"])
         rows.append({
             COL_NAME: name,
-            COL_LOADED_TOTAL: f"{len(loaded)}/{total_regions}",
-            COL_LOADED: ", ".join(loaded) if loaded else "none",
-            COL_NOT_FOUND: ", ".join(missing) if missing else "none",
+            COL_FOUND: info["found"],
+            COL_UNREADABLE: len(info["unreadable"]),
+            "unreadable_paths": info["unreadable"],
         })
     return rows
 
 
-def _print_combined_summary(rows):
-    """Print summary grouped by directory: base files first, then update files by directory."""
-    if not rows:
-        print("    No files found")
-        return
+MAX_LISTED_UNREADABLE = 3
 
+
+def _print_terse_health(rows: List[dict]):
+    """Print one folder-level row per directory (found/unreadable counts), with a
+    capped list of unreadable filenames underneath any folder that has them."""
+    by_dir = {}
+    for row in rows:
+        d = row.get("dir") or row[COL_NAME]
+        group = by_dir.setdefault(d, {"found": 0, "unreadable": 0, "paths": []})
+        group["found"] += row[COL_FOUND]
+        group["unreadable"] += row[COL_UNREADABLE]
+        group["paths"].extend(row["unreadable_paths"])
+
+    ordered_dirs = list(by_dir)  # base model first, then update folders in the order provided
+
+    print("\n    File health (folder: files found / unreadable):\n")
+    table = [[d, by_dir[d]["found"], by_dir[d]["unreadable"]] for d in ordered_dirs]
+    lines = tabulate(table, headers=["Folder", COL_FOUND, COL_UNREADABLE], tablefmt="simple").splitlines()
+    for line in lines:
+        print(f"      {line}")
+
+    for d in ordered_dirs:
+        group = by_dir[d]
+        if not group["unreadable"]:
+            continue
+        print(f"\n      Unreadable under {d}:")
+        for p in group["paths"][:MAX_LISTED_UNREADABLE]:
+            try:
+                p = p.relative_to(d)
+            except ValueError:
+                pass
+            print(f"        ! {p}")
+        remaining = len(group["paths"]) - MAX_LISTED_UNREADABLE
+        if remaining > 0:
+            print(f"        ! ... and {remaining} more")
+    if any(g["unreadable"] for g in by_dir.values()):
+        print("\n      (call model.print_file_health(verbose=True) for the full per-entry table)")
+
+
+def _print_verbose_health(rows: List[dict]):
+    """Print one row per update entry (sector/policy), grouped under its source folder."""
     # Format all rows together so column widths are consistent across groups
-    table = [[r[COL_NAME], r[COL_LOADED_TOTAL], r[COL_LOADED], r[COL_NOT_FOUND]] for r in rows]
-    lines = tabulate(table, headers=[COL_NAME, COL_LOADED_TOTAL, COL_LOADED, COL_NOT_FOUND], tablefmt="plain").splitlines()
+    table = [[r[COL_NAME], r[COL_FOUND], r[COL_UNREADABLE]] for r in rows]
+    lines = tabulate(table, headers=[COL_NAME, COL_FOUND, COL_UNREADABLE], tablefmt="plain").splitlines()
     header, data_lines = lines[0], lines[1:]
 
     print(f"      {header}")
@@ -52,46 +107,53 @@ def _print_combined_summary(rows):
             print(f"    {d}/")
         for i in indices:
             print(f"      {data_lines[i]}")
+            for p in rows[i]["unreadable_paths"]:
+                print(f"          ! unreadable: {p.name}")
 
 
-def _add_path(cur: Path, summary: dict, key: str, reg: str, found: List[str], missing: List[str]) -> None:
-    """Record a path as found or missing and update summary."""
-    if cur.exists():
-        found.append(str(cur))
-        summary[key]["loaded_regions"].add(reg)
+def print_file_health(rows: List[dict], verbose: bool = False):
+    """Print file health, rolled up per folder by default, or the full per-entry table if verbose.
+
+    Terse mode (default) reports one line per folder — found/unreadable file counts,
+    with unreadable filenames listed underneath only when there are any — since that's
+    the level a user actually decides at ("did my policies folder read ok?"), and the
+    per-entry (per sector/policy) breakdown is rarely needed. Pass verbose=True for that
+    full per-entry table instead.
+    """
+    if not rows:
+        print("    No files found")
+        return
+    if verbose:
+        _print_verbose_health(rows)
     else:
-        missing.append(str(cur))
-        summary[key]["missing_regions"].add(reg)
+        _print_terse_health(rows)
 
 
-def collect_base_paths(
-    model_path: str,
-    base_model: str,
-    region_list: Iterable[str],
-) -> Tuple[List[str], List[str], List[dict]]:
-    """Collect base model CSV paths and summarize loaded/not found regions."""
-    regions = list(region_list)
-    found, missing = [], []
-    summary = defaultdict(lambda: {"loaded_regions": set(), "missing_regions": set()})
-    total_regions = len(regions)
+def collect_base_files(model_path: str, base_model: str) -> Tuple[List[str], List[dict]]:
+    """Collect base model CSV paths and report which are readable.
 
-    for reg in regions:
-        cur = Path(model_path) / base_model / f"{base_model}_{reg}.csv"
-        _add_path(cur, summary, base_model, reg, found, missing)
+    Every CSV in the base model directory is collected for reading; whether a file
+    can actually be parsed (has the expected columns) is checked here, separately
+    from whether requested regions/sectors have any data (see print_coverage_matrix).
+    """
+    base_dir = Path(model_path) / base_model
+    found_paths = _glob_csvs(base_dir)
+    unreadable = [p for p in found_paths if not _scannable(str(p))]
 
-    rows = _build_rows(summary, total_regions)
-    return found, missing, rows
+    summary = {str(base_dir): {"found": len(found_paths), "unreadable": unreadable}}
+    rows = _build_rows(summary)
+    return [str(p) for p in found_paths], rows
 
 
-def collect_update_paths(
-    update_files: Mapping[str, Iterable[str]],
-    region_list: Iterable[str],
-) -> Tuple[List[str], List[str], List[dict]]:
-    """Collect update CSV paths and summarize loaded/not found regions."""
-    regions = list(region_list)
-    found, missing = [], []
-    summary = defaultdict(lambda: {"loaded_regions": set(), "missing_regions": set()})
-    total_regions = len(regions)
+def collect_update_files(update_files: Mapping[str, Iterable[str]]) -> Tuple[List[str], List[dict]]:
+    """Collect update CSV paths and report which are readable.
+
+    Every CSV in each update directory is collected for reading; whether a file
+    can actually be parsed (has the expected columns) is checked here, separately
+    from whether requested regions/sectors have any data (see print_coverage_matrix).
+    """
+    found = []
+    summary = {}
 
     key_to_dir = {}
     if update_files:
@@ -100,65 +162,130 @@ def collect_update_paths(
         for dir_name, file in all_entries:
             summary_key = str(Path(dir_name) / file) if file in duplicates else file
             key_to_dir[summary_key] = dir_name
-            for reg in regions:
-                cur = Path(dir_name) / file / f"{file}_{reg}.csv"
-                _add_path(cur, summary, summary_key, reg, found, missing)
 
-    rows = _build_rows(summary, total_regions)
+            sub_dir = Path(dir_name) / file
+            found_paths = _glob_csvs(sub_dir)
+            unreadable = [p for p in found_paths if not _scannable(str(p))]
+            summary[summary_key] = {"found": len(found_paths), "unreadable": unreadable}
+
+            found.extend(str(p) for p in found_paths)
+
+    rows = _build_rows(summary)
     for row in rows:
         d = key_to_dir.get(row[COL_NAME])
         row["dir"] = d
         if d:
             row[COL_NAME] = Path(row[COL_NAME]).name
-    return found, missing, rows
+    return found, rows
 
 
-def collect_all_paths(
+def _coverage_data(paths: Iterable[str]) -> Tuple[set, set]:
+    """Scan readable paths and return (pairs, region_only): the set of (Region, Sector)
+    combinations with both fields non-null, and the set of regions that have at least
+    one row with a null Sector.
+
+    Rows with a null Sector are core/structural rows not tied to any specific sector
+    (e.g. node/branch definitions) — they don't count toward a Region/Sector pair, but
+    their presence for a region is itself useful: it shows whether that region has any
+    data in the dataset at all, independent of sector-level content.
+    """
+    pairs = set()
+    region_only = set()
+    for path in paths:
+        if not _scannable(path):
+            continue
+        try:
+            df = pl.scan_csv(path, infer_schema_length=0).select(COL.region, COL.sector).collect()
+        except Exception:
+            continue
+        non_null = df.drop_nulls()
+        pairs.update(zip(non_null[COL.region].to_list(), non_null[COL.sector].to_list()))
+        no_sector = df.filter(pl.col(COL.sector).is_null() & pl.col(COL.region).is_not_null())
+        region_only.update(no_sector[COL.region].to_list())
+    return pairs, region_only
+
+
+def print_coverage_matrix(paths: Iterable[str], region_list: Iterable[str], sector_list: Iterable[str]):
+    """Print a region x sector matrix of which requested combinations have at least one row.
+
+    Built from the actual Region/Sector column values found across all readable
+    files combined, not from file or folder names — a single file may contain rows
+    for any mix of regions/sectors, so coverage can only be determined from the data.
+    """
+    regions = list(region_list)
+    sectors = list(sector_list)
+    if not regions or not sectors:
+        return
+
+    pairs, region_only = _coverage_data(paths)
+    table = [["(no sector)"] + ["x" if region in region_only else "." for region in regions]]
+    table.extend(
+        [sector] + ["x" if (region, sector) in pairs else "." for region in regions]
+        for sector in sectors
+    )
+    print("\n    Region x Sector coverage (x = data found, . = none found):\n")
+    print("      '(no sector)' row: does the region have any data at all, ignoring sector")
+    lines = tabulate(table, headers=["Sector"] + regions, tablefmt="simple").splitlines()
+    for line in lines:
+        print(f"      {line}")
+
+    covered_sectors = sum(1 for sector in sectors if any((region, sector) in pairs for region in regions))
+    print(f"\n      Summary: {covered_sectors} of {len(sectors)} requested sectors have data in at least one region.")
+
+
+def collect_files(
     model_path: str,
     base_model: str,
     region_list: Iterable[str],
+    sector_list: Iterable[str],
     update_files: Mapping[str, Iterable[str]],
-) -> Tuple[List[str], List[str]]:
+) -> Tuple[List[str], List[str], List[dict]]:
     """
-    Collect base and update paths, print a combined summary table, and return found lists.
-    Returns (base_found, update_found).
+    Collect base and update paths, print a summary, and return found lists plus health rows.
+    Returns (base_found, update_found, health_rows); health_rows can be re-printed later
+    via print_file_health(health_rows, verbose=True) for the full per-entry breakdown.
     """
-    base_found, _, base_rows = collect_base_paths(model_path, base_model, region_list)
-    update_found, _, update_rows = collect_update_paths(update_files, region_list)
+    base_found, base_rows = collect_base_files(model_path, base_model)
+    update_found, update_rows = collect_update_files(update_files)
+    health_rows = base_rows + update_rows
 
-    _print_combined_summary(base_rows + update_rows)
-    return base_found, update_found
-
-
-def _scannable(path: str) -> bool:
-    """Check a CSV has the columns filter_model_data requires, without fully reading it."""
-    try:
-        cols = pl.scan_csv(path, infer_schema_length=0).collect_schema().names()
-        return COL.sector in cols and COL.year in cols and COL.value in cols
-    except Exception:
-        return False
+    print_coverage_matrix(base_found + update_found, region_list, sector_list)
+    print_file_health(health_rows)
+    return base_found, update_found, health_rows
 
 
 def filter_model_data(
     paths: Iterable[str],
+    region_list: Iterable,
     sector_list: Iterable,
     year_list: Iterable,
     col_list: Iterable[str],
 ) -> pd.DataFrame:
-    """Read, concatenate, and filter model input CSVs by sector and year in one lazy pass.
+    """Read, concatenate, and filter model input CSVs by region, sector, and year in one lazy pass.
 
-    Rows with a null Sector or null Year are always kept (constants / non-sector-specific
-    rows). An empty/falsy sector_list applies no sector filtering.
+    Region, Sector, and Year are filtered independently: a row is dropped only if one of
+    its own values is non-null and not in the requested list. A null value in a column
+    always passes that column's filter, but doesn't exempt the row from the others.
+    An empty/falsy region_list or sector_list applies no filtering for that column.
+
+    Region files on disk carry some duplicated rows by design (e.g. national-level
+    defaults inlined into every per-region file), so exact-duplicate rows are dropped
+    after filtering.
+
+    Unreadable files are silently skipped here — they're already reported by
+    print_file_health/collect_files at collection time.
     """
     year_strs = [str(y) for y in year_list]
     sectors = list(sector_list) if sector_list else None
+    regions = list(region_list) if region_list else None
 
     lazy_frames = []
     for path in paths:
         if not _scannable(path):
-            print(f"Warning: Unable to parse csv_path at {path}. Skipping.")
             continue
         lf = pl.scan_csv(path, infer_schema_length=0)
+        if regions:
+            lf = lf.filter(pl.col(COL.region).is_in(regions) | pl.col(COL.region).is_null())
         if sectors:
             lf = lf.filter(pl.col(COL.sector).is_in(sectors) | pl.col(COL.sector).is_null())
         lf = lf.filter(pl.col(COL.year).is_in(year_strs) | pl.col(COL.year).is_null())
@@ -170,6 +297,7 @@ def filter_model_data(
     df = (
         pl.concat(lazy_frames, how="diagonal_relaxed")
         .collect()
+        .unique(maintain_order=True)
         .to_pandas()
         .replace({np.nan: None, "": None})
     )

--- a/src/CIMS/readers/helpers.py
+++ b/src/CIMS/readers/helpers.py
@@ -8,10 +8,12 @@ import pandas as pd
 import polars as pl
 
 from ..utils.model_description import column_list as COL
+from ..utils.parameter import list as PARAM
 
 COL_NAME = "File Name"
 COL_FOUND = "Files Found"
 COL_UNREADABLE = "Unreadable"
+REGION_COMPETITION_TYPE = "Region"
 
 
 def _glob_csvs(directory: Path) -> List[Path]:
@@ -254,6 +256,33 @@ def collect_files(
     return base_found, update_found, health_rows
 
 
+def _excluded_region_branches(paths: Iterable[str], regions: List[str]) -> set:
+    """Find branches that represent an excluded administrative region (e.g. a province
+    not in region_list), so its structural parent's unconditional request to it can be
+    dropped along with everything else about that region (see filter_model_data).
+
+    A branch is a region node if it has a competition row with Value == "Region"; its
+    own Region column value is the region it represents.
+    """
+    region_of_branch = {}
+    for path in paths:
+        if not _scannable(path):
+            continue
+        try:
+            df = (
+                pl.scan_csv(path, infer_schema_length=0)
+                .filter(pl.col(COL.parameter) == PARAM.competition_type)
+                .select(COL.branch, COL.region, COL.value)
+                .collect()
+            )
+        except Exception:
+            continue
+        region_rows = df.filter(pl.col(COL.value) == REGION_COMPETITION_TYPE)
+        region_of_branch.update(zip(region_rows[COL.branch].to_list(), region_rows[COL.region].to_list()))
+
+    return {branch for branch, region in region_of_branch.items() if region not in regions}
+
+
 def filter_model_data(
     paths: Iterable[str],
     region_list: Iterable,
@@ -265,19 +294,20 @@ def filter_model_data(
 
     Region, Sector, and Year are filtered independently: a row is dropped only if one of
     its own values is non-null and not in the requested list. A null value in a column
-    always passes that column's filter, but doesn't exempt the row from the others.
-    An empty/falsy region_list or sector_list applies no filtering for that column.
-
-    Region files on disk carry some duplicated rows by design (e.g. national-level
-    defaults inlined into every per-region file), so exact-duplicate rows are dropped
-    after filtering.
-
-    Unreadable files are silently skipped here — they're already reported by
+    always passes that column's filter, but doesn't exempt the row from the others. An
+    empty/falsy region_list or sector_list applies no filtering for that column. Exact
+    duplicate rows (e.g. national defaults inlined into every per-region file) are dropped
+    after filtering. Unreadable files are silently skipped — already reported by
     print_file_health/collect_files at collection time.
+
+    See _excluded_region_branches for the one exception to per-column independence: a
+    structural parent's unconditional request to an excluded region node is also dropped.
     """
     year_strs = [str(y) for y in year_list]
     sectors = list(sector_list) if sector_list else None
     regions = list(region_list) if region_list else None
+
+    excluded_region_branches = list(_excluded_region_branches(paths, regions)) if regions else []
 
     lazy_frames = []
     for path in paths:
@@ -289,6 +319,13 @@ def filter_model_data(
         if sectors:
             lf = lf.filter(pl.col(COL.sector).is_in(sectors) | pl.col(COL.sector).is_null())
         lf = lf.filter(pl.col(COL.year).is_in(year_strs) | pl.col(COL.year).is_null())
+        if excluded_region_branches:
+            is_structural_request_to_excluded_region = (
+                (pl.col(COL.parameter) == PARAM.service_request)
+                & pl.col(COL.target).is_in(excluded_region_branches)
+                & (pl.col(COL.branch) == pl.col(COL.target).str.replace(r"\.[^.]+$", ""))
+            )
+            lf = lf.filter(~is_structural_request_to_excluded_region)
         lazy_frames.append(lf)
 
     if not lazy_frames:

--- a/src/CIMS/readers/model_reader.py
+++ b/src/CIMS/readers/model_reader.py
@@ -1,7 +1,7 @@
 import numpy as np
-import pandas as pd
 import polars as pl
 
+from .helpers import filter_model_data
 from ..utils.model_description import column_list as COL
 from ..utils.parameter.parse import infer_type
 
@@ -28,35 +28,9 @@ class ModelReader:
         self.tech_dfs = {}
 
     def _get_model_df(self):
-        appended_data = []
-        for csv_file in self.csv_files:
-            try:
-                sheet_df = pl.read_csv(
-                    csv_file,
-                    use_pyarrow=False,
-                    infer_schema_length=0,
-                ).to_pandas().replace({np.nan: None, "": None})
-                appended_data.append(sheet_df)
-            except ValueError:
-                print(f"Warning: Unable to parse csv_path at {csv_file}. Skipping.")
-
-        model_df = pd.concat(appended_data, ignore_index=True)
-
-        meta_cols = [c for c in model_df.columns if c not in ("Year", "Value") and c in self.col_list]
-        year_mask = model_df["Year"].isin(self.year_list) | model_df["Year"].isna()
-        mdf = model_df[year_mask][meta_cols + ["Year", "Value"]]
-
-        return mdf
+        return filter_model_data(self.csv_files, self.sector_list, self.year_list, self.col_list)
 
     def get_model_description(self, inplace=False):
-        # ------------------------
-        # Filter sectors for calibration (if applicable)
-        # ------------------------
-        if self.sector_list:
-            if None not in self.sector_list:
-                self.sector_list.append(None)
-            self.model_df = self.model_df.apply(lambda row: row[self.model_df[COL.sector].isin(self.sector_list)])
-
         # ------------------------
         # Extract Node DFs
         # ------------------------

--- a/src/CIMS/readers/model_reader.py
+++ b/src/CIMS/readers/model_reader.py
@@ -1,13 +1,12 @@
 import numpy as np
 import polars as pl
 
-from .helpers import filter_model_data
 from ..utils.model_description import column_list as COL
 from ..utils.parameter.parse import infer_type
 
 
 class ModelReader:
-    def __init__(self, csv_file_paths, col_list, year_list, sector_list,
+    def __init__(self, model_df,
                  default_values_csv_path=None, node_col=COL.branch, root_node="CIMS", list_csv_path=None):
 
         if default_values_csv_path:
@@ -15,20 +14,13 @@ class ModelReader:
         if list_csv_path:
             self.list_csv = list_csv_path
 
-        self.csv_files = csv_file_paths
         self.node_col = node_col
-        self.col_list = col_list
-        self.year_list = [str(x) for x in year_list]
-        self.sector_list = sector_list
 
-        self.model_df = self._get_model_df()
+        self.model_df = model_df.copy()
         self.root = root_node
 
         self.node_dfs = {}
         self.tech_dfs = {}
-
-    def _get_model_df(self):
-        return filter_model_data(self.csv_files, self.sector_list, self.year_list, self.col_list)
 
     def get_model_description(self, inplace=False):
         # ------------------------

--- a/src/CIMS/readers/scenario_reader.py
+++ b/src/CIMS/readers/scenario_reader.py
@@ -1,7 +1,5 @@
-from .helpers import filter_model_data
 from .model_reader import ModelReader
 
-class ScenarioReader(ModelReader):
 
-    def _get_model_df(self):
-        return filter_model_data(self.csv_files, self.sector_list, self.year_list, self.col_list)
+class ScenarioReader(ModelReader):
+    """Marker subclass identifying scenario-update readers (see Model.update())."""

--- a/src/CIMS/readers/scenario_reader.py
+++ b/src/CIMS/readers/scenario_reader.py
@@ -1,31 +1,7 @@
-import numpy as np
-import pandas as pd
-import polars as pl
-
+from .helpers import filter_model_data
 from .model_reader import ModelReader
-from ..utils.model_description import column_list as COL
 
 class ScenarioReader(ModelReader):
 
     def _get_model_df(self):
-        appended_data = []
-        for csv_file in self.csv_files:
-            try:
-                sheet_df = pl.read_csv(
-                    csv_file,
-                    use_pyarrow=False,
-                    infer_schema_length=0,
-                ).to_pandas().replace({np.nan: None, "": None})
-                appended_data.append(sheet_df)
-
-            except ValueError:
-                print(f"Warning: Unable to parse scenario csv_path at {csv_file}. Skipping.")
-
-        if not appended_data:
-            return pd.DataFrame(columns=list(self.col_list) + ["Year", "Value"])
-
-        model_df = pd.concat(appended_data, ignore_index=True)
-
-        meta_cols = [c for c in model_df.columns if c not in ("Year", "Value") and c in self.col_list]
-        year_mask = model_df["Year"].isin(self.year_list) | model_df["Year"].isna()
-        return model_df[year_mask][meta_cols + ["Year", "Value"]]
+        return filter_model_data(self.csv_files, self.sector_list, self.year_list, self.col_list)

--- a/src/CIMS/readers/scenario_reader.py
+++ b/src/CIMS/readers/scenario_reader.py
@@ -1,5 +1,0 @@
-from .model_reader import ModelReader
-
-
-class ScenarioReader(ModelReader):
-    """Marker subclass identifying scenario-update readers (see Model.update())."""

--- a/src/CIMS/utils/model_description/columns_builder.py
+++ b/src/CIMS/utils/model_description/columns_builder.py
@@ -1,16 +1,12 @@
 import pandas as pd
-from typing import Iterable, List
+from typing import List
 
 
-def build_col_list(list_csv_path: str, year_list: Iterable) -> List[str]:
-    """
-    Build the column list from defaults_Lists.csv plus the provided years.
-    """
-    base_cols = (
+def build_col_list(list_csv_path: str) -> List[str]:
+    """Build the metadata column allowlist from defaults_Lists.csv's Columns field."""
+    return (
         pd.read_csv(list_csv_path)["Columns"]
         .dropna()
         .astype(str)
         .tolist()
     )
-    year_cols = [str(y) for y in year_list]
-    return base_cols + year_cols


### PR DESCRIPTION
Related to #571

## Summary

Previously, filtering by region, sector, and year happened in three separate places, using three different (and slightly inconsistent) approaches:

- **Region** — files are named per-region (e.g. `..._AB.csv`), so the model only ever opened the file for a requested region. Unchanged.
- **Sector** — the model read an *entire* CSV into memory, then discarded rows that didn't match the requested sector(s). This logic was duplicated, with small differences, across three classes (`ModelReader`, `ScenarioReader`, `ModelValidator`).
- **Year** — same pattern as sector, duplicated across the same three classes.

**What changed:** Sector and year filtering now happen in one shared function (`filter_model_data`), called once when the model is built (`Model.__init__`) or updated (`Model.update()`) — the individual reader/validator classes no longer read or filter files themselves.

This also switched from "read everything, then filter" to **lazy loading**: files are read and filtered in the same step, so unwanted rows are never fully loaded. This is faster and uses less memory on large files, but doesn't change which rows end up in the model.

**What did not change:**
- Filtering results — old vs. new logic was compared side-by-side against real model data across several filter combinations, with identical output every time.
- The normal way of building or updating a model (`Model(...)` / `model.update(...)`), with one small exception below.

**One interface change:** `model.update(...)` now takes update files in the same format as `Model(...)` uses when first building a model, making the two more consistent. A few internal helper classes (`ModelReader`, `ScenarioReader`, `ModelValidator`) were also removed from the list of things other code can import directly — they were never meant to be used outside the model-building process.

**Also included:** `ScenarioReader`, one of those helper classes, was removed entirely — it had become an empty duplicate of `ModelReader` with no remaining differences. This is tested and doesn't affect how updates are applied: leaving a cell blank (no change) vs. typing "None" (explicitly clear the value, so the model estimates/calculates it) still works exactly as before.

**Bug fix:** while adding test coverage for `model.update(...)`, we found and fixed a bug that would have made any real use of it crash. It had no existing callers or tests, so this had gone unnoticed.
